### PR TITLE
fix: responsive demo viewer + lobby; collapsible info sheet on mobile

### DIFF
--- a/src/framing.ts
+++ b/src/framing.ts
@@ -1,0 +1,124 @@
+import * as THREE from 'three';
+
+/**
+ * Responsive camera framing.
+ *
+ * A PerspectiveCamera's `fov` is VERTICAL, so the horizontal field of view shrinks with the
+ * viewport aspect. The per-demo cameras in `registry.ts` were art-directed against a wide
+ * desktop stage (~16:10); on a phone in portrait (aspect ~0.46) the horizontal frame collapses
+ * to a third of its authored width and wide subjects — bikes, shotguns, dioramas — fall
+ * completely outside the frame. The helpers below compute how far a camera has to be dollied
+ * back so the subject fits on BOTH axes, whatever the viewport.
+ */
+
+/** True for shadow-catcher planes — huge, invisible, and not part of the subject's silhouette. */
+function isShadowCatcher(mesh: THREE.Mesh): boolean {
+  const material = mesh.material;
+  const materials = Array.isArray(material) ? material : [material];
+  return materials.every((mat) => mat instanceof THREE.ShadowMaterial);
+}
+
+/**
+ * Union bounding box (world space) of every mesh under `object` that contributes to the visible
+ * silhouette. Shadow-catcher ground planes (up to 30 units across) and hidden meshes are skipped
+ * so they can't inflate the fit and shrink the subject to a dot.
+ */
+export function meshBounds(object: THREE.Object3D): THREE.Box3 {
+  const box = new THREE.Box3();
+  const meshBox = new THREE.Box3();
+  object.updateWorldMatrix(true, true);
+  object.traverse((node) => {
+    const mesh = node as THREE.Mesh;
+    if (!mesh.isMesh || !mesh.geometry) return;
+    if (!mesh.visible || isShadowCatcher(mesh)) return;
+    // Per-mesh geometry bounds (rather than expandByObject) so a skipped descendant is never
+    // pulled back in through its parent's subtree.
+    if (!mesh.geometry.boundingBox) mesh.geometry.computeBoundingBox();
+    if (!mesh.geometry.boundingBox) return;
+    meshBox.copy(mesh.geometry.boundingBox).applyMatrix4(mesh.matrixWorld);
+    box.union(meshBox);
+  });
+  return box;
+}
+
+/** The subject as a cylinder around the vertical orbit axis through the camera target. */
+export interface SubjectExtent {
+  /** Largest horizontal distance from the orbit axis — the silhouette half-width at any angle. */
+  horizontal: number;
+  /** Largest vertical distance from the target. */
+  vertical: number;
+}
+
+/**
+ * Measures `objects` as a cylinder centred on the vertical axis through `target`.
+ *
+ * Measuring around the orbit target rather than the box centre preserves the authored
+ * composition (the subject stays where the demo put it in frame), and a cylinder — rather than a
+ * sphere — is what an orbiting camera actually sees: the fit holds at every azimuth without
+ * inflating the horizontal requirement with the subject's height.
+ */
+export function subjectExtent(objects: THREE.Object3D[], target: THREE.Vector3): SubjectExtent {
+  const box = new THREE.Box3();
+  for (const object of objects) box.union(meshBounds(object));
+  if (box.isEmpty()) return { horizontal: 0, vertical: 0 };
+
+  const extent: SubjectExtent = { horizontal: 0, vertical: 0 };
+  for (const x of [box.min.x, box.max.x]) {
+    for (const z of [box.min.z, box.max.z]) {
+      extent.horizontal = Math.max(extent.horizontal, Math.hypot(x - target.x, z - target.z));
+    }
+  }
+  for (const y of [box.min.y, box.max.y]) {
+    extent.vertical = Math.max(extent.vertical, Math.abs(y - target.y));
+  }
+  return extent;
+}
+
+/** Viewport aspect the demo cameras in registry.ts were art-directed against (a wide desktop). */
+export const REFERENCE_ASPECT = 1.6;
+
+/**
+ * Multiplier to apply to a demo's authored camera distance so `aspect` frames the subject the way
+ * the reference aspect did. Returns exactly 1 at (and above) the reference aspect, so desktop
+ * framing is never touched — including the demos that deliberately crop in tight, whose tightness
+ * is measured and carried over rather than "corrected".
+ */
+export function fitScale(
+  extent: SubjectExtent,
+  fovDeg: number,
+  aspect: number,
+  authoredDistance: number,
+  reference = REFERENCE_ASPECT,
+): number {
+  const here = fitDistance(extent, fovDeg, aspect);
+  const atReference = fitDistance(extent, fovDeg, Math.max(aspect, reference));
+  if (here <= 0 || atReference <= 0 || authoredDistance <= 0) return 1;
+  // <1 when the demo framed tighter than a guaranteed fit — i.e. an intentional crop.
+  const tightness = Math.min(1, authoredDistance / atReference);
+  return Math.max(1, (here * tightness) / authoredDistance);
+}
+
+/**
+ * Camera distance at which `extent` fits inside both axes of the frame, at any orbit angle.
+ *
+ * `margin` is the breathing room around the subject. It cancels out for demos that crop
+ * deliberately (see `fitScale`), so it only sets how tightly the demos that DO fit are framed.
+ */
+export function fitDistance(
+  extent: SubjectExtent,
+  fovDeg: number,
+  aspect: number,
+  margin = 1.15,
+): number {
+  const { horizontal, vertical } = extent;
+  if (horizontal <= 0 && vertical <= 0) return 0;
+
+  const halfV = (fovDeg * Math.PI) / 360;
+  const halfH = Math.atan(Math.tan(halfV) * Math.max(0.05, aspect));
+  // Horizontally the silhouette is a circle of radius `horizontal`, so the tangent-distance
+  // formula is exact. Vertically it is a flat extent that can sit up to `horizontal` closer to
+  // the camera, which is what that term pays for.
+  const forWidth = horizontal / Math.sin(halfH);
+  const forHeight = vertical / Math.tan(halfV) + horizontal;
+  return Math.max(forWidth, forHeight) * margin;
+}

--- a/src/hero-stage.ts
+++ b/src/hero-stage.ts
@@ -5,9 +5,12 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
 import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 import type { DemoEntry } from './demos/registry';
+import { fitScale, subjectExtent, type SubjectExtent } from './framing';
 
 const CYCLE_MS = 5200; // time each demo stays on the turntable
 const MATERIALIZE_S = 1.05; // entry animation length
+/** Aspect of the hero stage in the desktop two-column layout — the framing to reproduce. */
+const STAGE_REFERENCE_ASPECT = 1.11;
 
 /**
  * Cinematic hero turntable: builds each demo in turn, orbits a camera around it
@@ -31,6 +34,12 @@ export class HeroStage {
   private orbitRadius = 3;
   private orbitAngle = 0;
   private orbitHeight = 1;
+  /** Authored orbit geometry of the active demo, before any responsive pull-back. */
+  private authoredRadius = 3;
+  private authoredHeight = 1;
+  private authoredDistance = 3;
+  private fitExtent: SubjectExtent | null = null;
+  private fogBase: { near: number; far: number } | null = null;
 
   private activeObjects: THREE.Object3D[] = [];
   private index = -1;
@@ -129,6 +138,38 @@ export class HeroStage {
     this.camera.updateProjectionMatrix();
     this.renderer.setSize(w, h, false);
     this.composer.setSize(w, h);
+    this.applyFit();
+  }
+
+  /**
+   * Scales the turntable orbit out until the subject fits the stage on both axes. The stage is
+   * near-square on desktop but tall and narrow on a phone, where the authored radius would clip
+   * wide subjects (a bike, a shotgun) off both edges.
+   */
+  private applyFit(): void {
+    if (!this.fitExtent || this.authoredDistance <= 0) return;
+    const scale = fitScale(
+      this.fitExtent,
+      this.camera.fov,
+      this.camera.aspect,
+      this.authoredDistance,
+      STAGE_REFERENCE_ASPECT,
+    );
+    // On a phone the authored crop reads as an accident rather than a composition, and the subject
+    // collides with the source-photo inset — buy a little extra room back. Keyed to the viewport
+    // (not the stage width) so the desktop stage, which is only ~510px wide, is left alone.
+    const room = window.innerWidth <= 640 ? 1.12 : 1;
+    this.orbitRadius = this.authoredRadius * scale * room;
+    this.orbitHeight = this.authoredHeight * scale * room;
+    const reach = Math.max(this.fitExtent.horizontal, this.fitExtent.vertical);
+    this.camera.far = Math.max(100, this.authoredDistance * scale * room + reach * 6);
+    this.camera.updateProjectionMatrix();
+    // A pulled-back camera would otherwise sit outside a demo's fog range and fade the subject
+    // to nothing; scale the range with the pull-back so the look is preserved.
+    if (this.fogBase && this.scene.fog instanceof THREE.Fog) {
+      this.scene.fog.near = this.fogBase.near * scale * room;
+      this.scene.fog.far = this.fogBase.far * scale * room;
+    }
   }
 
   private clearActive(): void {
@@ -149,6 +190,8 @@ export class HeroStage {
     this.clearActive();
     const demo = this.demos[index];
     const before = new Set(this.scene.children);
+    // Reset fog so a previous demo's atmosphere doesn't leak onto this one.
+    this.scene.fog = null;
     demo.build(this.scene);
     // Some demos set an opaque scene.background; keep the hero canvas transparent
     // so the CSS aurora shows through.
@@ -160,11 +203,17 @@ export class HeroStage {
     this.target.set(tx, ty, tz);
     const dx = px - tx;
     const dz = pz - tz;
-    this.orbitRadius = Math.hypot(dx, dz);
+    this.authoredRadius = Math.hypot(dx, dz);
+    this.authoredHeight = py - ty;
+    this.authoredDistance = Math.hypot(this.authoredRadius, this.authoredHeight);
     this.orbitAngle = Math.atan2(dz, dx);
-    this.orbitHeight = py - ty;
     this.camera.fov = demo.cameraFov;
     this.camera.updateProjectionMatrix();
+
+    this.fitExtent = subjectExtent(this.activeObjects, this.target);
+    const fog = this.scene.fog as THREE.Fog | null;
+    this.fogBase = fog instanceof THREE.Fog ? { near: fog.near, far: fog.far } : null;
+    this.applyFit();
 
     this.entryStart = this.elapsed;
     this.index = index;

--- a/src/pages/demo.ts
+++ b/src/pages/demo.ts
@@ -5,6 +5,16 @@ import { navigate } from '../router';
 
 const GITHUB_URL = 'https://github.com/hoainho/img2threejs';
 
+/** Viewports where the info panel becomes a collapsible bottom sheet over the model. */
+const COMPACT_QUERY = '(max-width: 860px), (max-height: 520px)';
+
+/**
+ * Whether the details sheet is expanded, remembered across demo navigations within a session.
+ * `null` = untouched, so each viewport gets its own sensible default (open on desktop, collapsed
+ * on a phone, where an open panel would cover the model entirely).
+ */
+let panelExpanded: boolean | null = null;
+
 /**
  * Renders the full-viewport demo viewer + info panel for `id`.
  * Returns a cleanup function the router must call before switching routes.
@@ -17,52 +27,74 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
     return () => {};
   }
 
+  const compact = window.matchMedia(COMPACT_QUERY);
+  const expanded = panelExpanded ?? !compact.matches;
+
   mount.innerHTML = `
     <div class="demo-page">
       <div class="demo-canvas-mount" id="demo-canvas-mount"></div>
-      <div class="demo-panel">
-        <a class="back-link" href="#/"><span class="back-arrow">&larr;</span> Back to gallery</a>
-        <header class="demo-panel-head">
-          <span class="demo-kicker">img2threejs · reconstruction</span>
-          <h2>${demo.title}</h2>
-          <p class="demo-author">by
-            <a href="${demo.authorUrl}" target="_blank" rel="noopener noreferrer">${demo.author}</a>
-          </p>
-        </header>
-        <figure class="demo-ref">
-          <img class="demo-ref-thumb" src="${demo.referenceImage}" alt="${demo.title} reference" />
-          <figcaption>source reference</figcaption>
-        </figure>
-        <div class="demo-meta">
-          <div class="badges">
-            <span class="badge badge-${demo.subjectClass}">${demo.subjectClass}</span>
-            <span class="badge">${demo.generatedWith}</span>
-            <span class="badge badge-status status-${demo.status}">${demo.status}</span>
-          </div>
-          <p>${demo.blurb}</p>
-        </div>
-        <section class="demo-parts" id="demo-parts" hidden>
-          <div class="parts-head">
-            <span class="parts-title">Parts</span>
-            <span class="parts-count" id="parts-count"></span>
-          </div>
-          <div class="part-card" id="part-card" hidden></div>
-          <div class="parts-scroll"><ul class="parts-list" id="parts-list"></ul></div>
-          <p class="parts-prov" id="parts-prov" hidden></p>
-        </section>
-        <div class="demo-links">
-          <button class="btn btn-explode" id="demo-explode" type="button" aria-pressed="false" hidden>
-            <span class="explode-glyph">&#10021;</span> <span class="explode-label">Explode parts</span>
+      <section class="demo-panel" id="demo-panel" data-expanded="${expanded}">
+        <div class="demo-panel-bar">
+          <a class="back-link" href="#/" aria-label="Back to gallery">
+            <span class="back-arrow" aria-hidden="true">&larr;</span>
+            <span class="back-text">Back to gallery</span>
+          </a>
+          <span class="demo-bar-title">${demo.title}</span>
+          <button class="panel-toggle" type="button" id="panel-toggle"
+                  aria-controls="demo-panel-body" aria-expanded="${expanded}">
+            <span class="panel-toggle-label">Details</span>
+            <span class="panel-toggle-chevron" aria-hidden="true"></span>
           </button>
-          <a class="btn" href="${demo.sourceUrl}" target="_blank" rel="noopener noreferrer">
-            &lt;/&gt; View generated source
-          </a>
-          <a class="btn btn-star" href="${GITHUB_URL}" target="_blank" rel="noopener noreferrer">
-            &#9733; Star img2threejs on GitHub
-          </a>
         </div>
+        <div class="demo-panel-body" id="demo-panel-body">
+          <div class="demo-panel-inner">
+            <header class="demo-panel-head">
+              <span class="demo-kicker">img2threejs · reconstruction</span>
+              <h2>${demo.title}</h2>
+              <p class="demo-author">by
+                <a href="${demo.authorUrl}" target="_blank" rel="noopener noreferrer">${demo.author}</a>
+              </p>
+            </header>
+            <figure class="demo-ref">
+              <img class="demo-ref-thumb" src="${demo.referenceImage}" alt="${demo.title} reference" />
+              <figcaption>source reference</figcaption>
+            </figure>
+            <div class="demo-meta">
+              <div class="badges">
+                <span class="badge badge-${demo.subjectClass}">${demo.subjectClass}</span>
+                <span class="badge">${demo.generatedWith}</span>
+                <span class="badge badge-status status-${demo.status}">${demo.status}</span>
+              </div>
+              <p>${demo.blurb}</p>
+            </div>
+            <section class="demo-parts" id="demo-parts" hidden>
+              <div class="parts-head">
+                <span class="parts-title">Parts</span>
+                <span class="parts-count" id="parts-count"></span>
+              </div>
+              <div class="part-card" id="part-card" hidden></div>
+              <div class="parts-scroll"><ul class="parts-list" id="parts-list"></ul></div>
+              <p class="parts-prov" id="parts-prov" hidden></p>
+            </section>
+            <div class="demo-links">
+              <button class="btn btn-explode" id="demo-explode" type="button" aria-pressed="false" hidden>
+                <span class="explode-glyph">&#10021;</span> <span class="explode-label">Explode parts</span>
+              </button>
+              <a class="btn" href="${demo.sourceUrl}" target="_blank" rel="noopener noreferrer">
+                &lt;/&gt; View generated source
+              </a>
+              <a class="btn btn-star" href="${GITHUB_URL}" target="_blank" rel="noopener noreferrer">
+                &#9733; Star img2threejs on GitHub
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+      <div class="hint" id="demo-hint">
+        <span class="hint-glyph" aria-hidden="true">&#8635;</span>
+        <span class="hint-pointer">drag to orbit &middot; scroll to zoom</span>
+        <span class="hint-touch">drag to orbit &middot; pinch to zoom</span>
       </div>
-      <div class="hint"><span class="hint-glyph">&#8635;</span> drag to orbit &middot; scroll to zoom</div>
     </div>
   `;
 
@@ -98,6 +130,9 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
 
   const model = demo.build(viewer.scene);
   viewer.setExplodeRoot(model);
+  // Responsive framing: keeps the authored desktop composition, dollies back on narrow/short
+  // viewports so the whole subject stays in frame instead of being cropped away.
+  viewer.fitToViewport(model);
 
   // Part tree published for the assembly gate (forge/stage4_review/check_part_coverage.py).
   // Set in capture mode too — that is the headless run the gate reads it from.
@@ -233,8 +268,13 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
         ].filter(Boolean).join(' · ');
       }
 
-      mount.querySelector<HTMLElement>('.hint')!
-        .append(' · click a part to inspect · click again to reach what is behind it');
+      // Wrapped in its own span so the compact layout can drop it: the hint is a single-line
+      // pill, and this clause alone is wider than a phone screen.
+      const inspectHint = document.createElement('span');
+      inspectHint.className = 'hint-extra';
+      inspectHint.textContent =
+        ' · click a part to inspect · click again to reach what is behind it';
+      mount.querySelector<HTMLElement>('.hint')!.append(inspectHint);
     }
   }
 
@@ -245,7 +285,7 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
     viewer.scene.traverse((o) => {
       if ((o.userData as { tick?: unknown }).tick) delete (o.userData as { tick?: unknown }).tick;
     });
-    for (const sel of ['.demo-panel', '.hint', '.back-link']) {
+    for (const sel of ['.demo-panel', '.hint']) {
       mount.querySelector<HTMLElement>(sel)?.style.setProperty('display', 'none');
     }
     // Side-on auto-framing so the evaluation silhouette matches the side-on reference plate.
@@ -253,5 +293,41 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
   }
   viewer.start();
 
-  return () => viewer.dispose();
+  // --- collapsible details sheet ---------------------------------------------------------
+  const panel = mount.querySelector<HTMLElement>('#demo-panel')!;
+  const bar = mount.querySelector<HTMLElement>('.demo-panel-bar')!;
+  const toggle = mount.querySelector<HTMLButtonElement>('#panel-toggle')!;
+  const setExpanded = (next: boolean): void => {
+    panelExpanded = next;
+    panel.dataset.expanded = String(next);
+    toggle.setAttribute('aria-expanded', String(next));
+  };
+  // The whole bar is the hit target (the button's click bubbles up to it), so a sheet on a phone
+  // toggles from anywhere along the header — everywhere except the back link.
+  const onBarClick = (event: MouseEvent): void => {
+    if ((event.target as HTMLElement).closest('.back-link')) return;
+    setExpanded(panel.dataset.expanded !== 'true');
+  };
+  bar.addEventListener('click', onBarClick);
+
+  // Viewport changes reset an untouched panel to that viewport's default (rotating a phone to
+  // landscape, resizing a window across the breakpoint).
+  const onCompactChange = (event: MediaQueryListEvent): void => {
+    if (panelExpanded === null) setExpanded(!event.matches);
+  };
+  compact.addEventListener('change', onCompactChange);
+
+  // --- orbit hint: says its piece, then gets out of the way ------------------------------
+  const hint = mount.querySelector<HTMLElement>('#demo-hint')!;
+  const hideHint = (): void => hint.classList.add('is-gone');
+  const hintTimer = window.setTimeout(hideHint, 6000);
+  canvasMount.addEventListener('pointerdown', hideHint, { once: true });
+
+  return () => {
+    window.clearTimeout(hintTimer);
+    bar.removeEventListener('click', onBarClick);
+    compact.removeEventListener('change', onCompactChange);
+    canvasMount.removeEventListener('pointerdown', hideHint);
+    viewer.dispose();
+  };
 }

--- a/src/pages/home.ts
+++ b/src/pages/home.ts
@@ -44,7 +44,7 @@ export function renderHome(mount: HTMLElement): () => void {
             &#9829; Sponsor
           </a>
           <a class="nav-star" href="${GITHUB_URL}" target="_blank" rel="noopener noreferrer">
-            &#9733; Star on GitHub
+            &#9733; Star <span class="nav-label-long">on GitHub</span>
           </a>
         </div>
       </header>

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
+import { fitScale, subjectExtent, type SubjectExtent } from './framing';
 
 export interface ViewerOptions {
   /** Install per-demo lights into the scene. Falls back to a neutral studio rig. */
@@ -158,6 +159,16 @@ export class Viewer {
   private camGoal: { target: THREE.Vector3; dist: number } | null = null;
   private camRest: { target: THREE.Vector3; dist: number } | null = null;
 
+  // ---- responsive framing ----
+  /** Distance the demo authored (|cameraPosition - cameraTarget|) — the desktop framing. */
+  private readonly authoredDistance: number;
+  private readonly authoredFar: number;
+  /** Subject size around the orbit target; null until fitToViewport() runs. */
+  private fitExtent: SubjectExtent | null = null;
+  /** Distance applyFit() last set, so a resize can preserve the user's own zoom. */
+  private appliedDistance = 0;
+  private fogBase: { near: number; far: number } | null = null;
+
   constructor(mount: HTMLElement, options: ViewerOptions = {}) {
     this.mount = mount;
 
@@ -205,6 +216,9 @@ export class Viewer {
     const [tx, ty, tz] = options.cameraTarget ?? [0, 0, 0];
     this.controls.target.set(tx, ty, tz);
     this.controls.update();
+
+    this.authoredDistance = this.camera.position.distanceTo(this.controls.target);
+    this.authoredFar = this.camera.far;
 
     if (options.installLights) {
       options.installLights(this.scene);
@@ -721,6 +735,76 @@ export class Viewer {
     this.camera.aspect = width / Math.max(1, height);
     this.camera.updateProjectionMatrix();
     this.renderer.setSize(width, height);
+    this.applyFit();
+  }
+
+  /**
+   * Makes the framing responsive: measures `object` around the orbit target and dollies the
+   * camera back far enough that it fits the current viewport on both axes. On a desktop-shaped
+   * viewport the authored distance already fits, so nothing moves; in portrait — where the
+   * horizontal fov collapses and the subject would fall outside the frame — the camera pulls
+   * back. Call once, AFTER the demo's build(). Re-applied automatically on resize/rotate.
+   */
+  fitToViewport(object: THREE.Object3D | THREE.Object3D[]): void {
+    // Capture mode owns its own deterministic framing (frameForCapture) — leave it alone.
+    if (this.capture) return;
+    const objects = Array.isArray(object) ? object : [object];
+    this.fitExtent = subjectExtent(objects, this.controls.target);
+    const fog = this.scene.fog;
+    this.fogBase = fog instanceof THREE.Fog ? { near: fog.near, far: fog.far } : null;
+    this.applyFit();
+  }
+
+  private applyFit(): void {
+    if (!this.fitExtent || this.authoredDistance <= 0) return;
+
+    const scale = fitScale(
+      this.fitExtent,
+      this.camera.fov,
+      this.camera.aspect,
+      this.authoredDistance,
+    );
+    const desired = this.authoredDistance * scale;
+    if (this.appliedDistance && Math.abs(desired - this.appliedDistance) < 1e-3) return;
+
+    // The camera distance is only the viewer's to keep when nothing else is driving it. While an
+    // explode or a part-focus is running, that system owns the distance, and reading it back here
+    // would fold its dolly (up to 3.4x) into the framing and leave the camera stranded once the
+    // animation settles. In that case leave the position alone and just re-base the other owners.
+    const driven = this.explodeT > 0 || this.explodeTarget > 0 || this.camGoal !== null;
+    const offset = this.camera.position.clone().sub(this.controls.target);
+    // Keep whatever zoom the user dialled in, expressed relative to the last fit distance.
+    const userZoom = !driven && this.appliedDistance
+      ? (offset.length() || 1) / this.appliedDistance
+      : 1;
+    const distance = desired * userZoom;
+    if (!driven) {
+      offset.setLength(distance);
+      this.camera.position.copy(this.controls.target).add(offset);
+    }
+
+    // Re-base the other camera-distance owners onto the new framing, so an explode or a focus
+    // that starts (or is mid-flight) across a resize dollies from the right distance instead of
+    // snapping back to the pre-resize one.
+    const framingRatio = this.appliedDistance ? desired / this.appliedDistance : 1;
+    if (framingRatio !== 1) {
+      this.explodeBaseDist *= framingRatio;
+      if (this.camRest) this.camRest.dist *= framingRatio;
+      if (this.camGoal) this.camGoal.dist *= framingRatio;
+    }
+    this.appliedDistance = desired;
+
+    // A dollied-back camera can push the subject past the authored far plane, and past a
+    // demo's fog range (which would fade it to nothing) — scale both with the pull-back.
+    const reach = Math.max(this.fitExtent.horizontal, this.fitExtent.vertical);
+    this.camera.far = Math.max(this.authoredFar, distance + reach * 6);
+    this.camera.updateProjectionMatrix();
+    if (this.fogBase && this.scene.fog instanceof THREE.Fog) {
+      const k = distance / this.authoredDistance;
+      this.scene.fog.near = this.fogBase.near * k;
+      this.scene.fog.far = this.fogBase.far * k;
+    }
+    this.controls.update();
   }
 
   start(): void {

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,10 +32,12 @@ body {
 
 body {
   overflow-x: hidden;
+  -webkit-text-size-adjust: 100%;
 }
 
 #app {
   min-height: 100vh;
+  min-height: 100dvh;
   width: 100%;
 }
 
@@ -58,7 +60,9 @@ code,
 .home {
   position: relative;
   min-height: 100vh;
-  overflow: hidden;
+  min-height: 100dvh;
+  overflow: clip;
+  padding-top: env(safe-area-inset-top);
 }
 
 .aurora {
@@ -97,6 +101,8 @@ code,
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .brand {
@@ -214,6 +220,7 @@ code,
 
 .hero-title {
   font-size: clamp(2.1rem, 5vw, 3.5rem);
+  text-wrap: balance;
   line-height: 1.08;
   letter-spacing: -0.02em;
   margin: 0.9rem 0 0;
@@ -474,7 +481,8 @@ code,
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
+  /* min() keeps the track from overflowing viewports narrower than the 270px minimum */
+  grid-template-columns: repeat(auto-fit, minmax(min(270px, 100%), 1fr));
   gap: 1.4rem;
 }
 
@@ -498,12 +506,24 @@ code,
   to { opacity: 1; transform: none; }
 }
 
-.card:hover,
+/* Hover lift only where hovering exists — on touch it would stick after a tap. */
+@media (hover: hover) {
+  .card:hover {
+    border-color: transparent;
+    transform: translateY(-4px);
+    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(124, 159, 255, 0.6),
+      0 0 30px rgba(124, 159, 255, 0.25);
+  }
+}
+
 .card.active {
   border-color: transparent;
-  transform: translateY(-4px);
   box-shadow: 0 18px 44px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(124, 159, 255, 0.6),
     0 0 30px rgba(124, 159, 255, 0.25);
+}
+
+.card:active {
+  transform: scale(0.985);
 }
 
 .card-media {
@@ -616,14 +636,176 @@ code,
   font-family: var(--mono);
 }
 
+/* ---------- Home responsive ---------- */
+
+@media (max-width: 1024px) {
+  .nav,
+  .hero,
+  .gallery,
+  .footer {
+    padding-left: 1.15rem;
+    padding-right: 1.15rem;
+  }
+  .hero {
+    gap: 1.8rem;
+  }
+}
+
 @media (max-width: 860px) {
   .hero {
     grid-template-columns: 1fr;
-    gap: 1.6rem;
+    gap: 1.5rem;
+    padding-top: 1.9rem;
+    align-items: start;
+  }
+  /* stage first: the 3D is the pitch */
+  .hero-stage {
+    min-height: min(78vw, 420px);
+    order: -1;
+  }
+  .hero-sub {
+    font-size: 0.98rem;
+  }
+  .gallery {
+    padding-top: 2.6rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .nav {
+    padding: 1rem 0.95rem 0;
+    gap: 0.5rem;
+  }
+  .brand-mark {
+    width: 26px;
+    height: 26px;
+  }
+  .brand-name {
+    font-size: 0.95rem;
+  }
+  .nav-actions {
+    gap: 0.4rem;
+  }
+  .nav-star,
+  .nav-donate {
+    font-size: 0.72rem;
+    padding: 0.38rem 0.68rem;
+    white-space: nowrap;
+  }
+
+  .hero {
+    padding: 1.5rem 0.95rem 0.5rem;
+    gap: 1.3rem;
+  }
+  .hero-eyebrow {
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+  }
+  .hero-title {
+    font-size: clamp(1.8rem, 8.6vw, 2.5rem);
+    margin-top: 0.7rem;
+  }
+  .hero-sub {
+    font-size: 0.93rem;
+    line-height: 1.62;
+    margin-top: 0.85rem;
+  }
+  .cta-row {
+    margin-top: 1.25rem;
+    gap: 0.55rem;
+  }
+  .cta-row .btn {
+    flex: 1 1 9rem;
+    justify-content: center;
+    font-size: 0.82rem;
+    padding: 0.72rem 0.85rem;
+  }
+  .pipeline {
+    margin-top: 1.5rem;
+    font-size: 0.71rem;
+    gap: 0.4rem;
+  }
+  .pipeline li:not(.pip-arrow) {
+    padding: 0.34rem 0.55rem;
+  }
+  /* the chips wrap, which leaves an arrow dangling at the end of a row — numbers carry the order */
+  .pip-arrow {
+    display: none;
+  }
+
+  .hero-stage {
+    min-height: 340px;
+    border-radius: 18px;
+  }
+  .stage-input {
+    width: 72px;
+    top: 12px;
+    left: 12px;
+    border-radius: 10px;
+  }
+  /* tight enough for "source photo" to stay on one line inside a 72px inset */
+  .stage-input figcaption {
+    font-size: 0.5rem;
+    letter-spacing: 0.02em;
+  }
+  /* the beam needs the desktop gap between thumb and model to read as a beam */
+  .stage-beam {
+    display: none;
+  }
+  /* full-width caption strip so a long title can't collide with the corner hint */
+  .stage-badge {
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    font-size: 0.7rem;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .stage-hint {
+    top: 14px;
+    right: 12px;
+    bottom: auto;
+    font-size: 0.6rem;
+  }
+
+  .gallery {
+    padding: 2.3rem 0.95rem 0.5rem;
+  }
+  .gallery-head p {
+    font-size: 0.9rem;
+    margin-bottom: 1.4rem;
+  }
+  .grid {
+    gap: 1rem;
+  }
+  .card-body {
+    padding: 0.85rem 0.9rem 1rem;
+    gap: 0.45rem;
+  }
+  /* one column — nothing left to align badges against, so drop the reserved second line */
+  .card-title {
+    min-height: 0;
+    font-size: 1rem;
+  }
+
+  .footer {
+    margin-top: 2.6rem;
+    padding: 1.2rem 0.95rem calc(1.2rem + env(safe-area-inset-bottom));
+    font-size: 0.78rem;
+    line-height: 1.7;
+    text-align: center;
+  }
+}
+
+/* Very narrow (≤360px): shed the longest labels rather than wrap the nav. */
+@media (max-width: 400px) {
+  .nav-label-long {
+    display: none;
   }
   .hero-stage {
-    min-height: 360px;
-    order: -1;
+    min-height: 300px;
   }
 }
 
@@ -644,6 +826,11 @@ code,
     opacity: 1;
     transform: none;
   }
+  .demo-panel-body,
+  .panel-toggle-chevron,
+  .hint {
+    transition: none;
+  }
 }
 
 /* ---------- Demo page ---------- */
@@ -651,53 +838,183 @@ code,
 .demo-page {
   position: relative;
   height: 100vh;
+  /* dvh tracks the collapsing mobile browser chrome; vh above is the fallback. */
+  height: 100dvh;
   width: 100%;
   overflow: hidden;
+  overscroll-behavior: none;
 }
 
 .demo-canvas-mount {
   position: absolute;
   inset: 0;
+  /* the canvas owns all gestures — no page pan/zoom fighting the orbit controls */
+  touch-action: none;
 }
+
+/* --- info panel: a collapsible card on desktop, a bottom sheet on a phone --- */
 
 .demo-panel {
   position: absolute;
-  top: 1rem;
-  left: 1rem;
+  top: max(1rem, env(safe-area-inset-top));
+  left: max(1rem, env(safe-area-inset-left));
+  z-index: 4;
   width: min(320px, calc(100vw - 2rem));
-  max-height: calc(100vh - 2rem);
-  overflow-y: auto;
-  background: rgba(16, 17, 22, 0.86);
-  backdrop-filter: blur(10px);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.8rem;
+  background: rgba(16, 17, 22, 0.88);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+
+.demo-panel-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 0.85rem;
+  flex: 0 0 auto;
+}
+
+.demo-panel[data-expanded='true'] .demo-panel-bar {
+  border-bottom: 1px solid var(--border);
 }
 
 .demo-panel .back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   font-family: var(--mono);
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   color: var(--text-dim);
+  transition: color 0.18s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.demo-panel .back-link:hover {
+  color: var(--text);
+}
+
+.back-arrow {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+/* The bar only needs to name the demo while the body is folded away. */
+.demo-bar-title {
+  display: none;
+  min-width: 0;
+  flex: 1 1 auto;
+  font-size: 0.9rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.panel-toggle {
+  margin-left: auto;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.34rem 0.62rem;
+  cursor: pointer;
+  transition: color 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.panel-toggle:hover,
+.panel-toggle:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.panel-toggle-chevron {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-right: 1.6px solid currentColor;
+  border-bottom: 1.6px solid currentColor;
+  /* points up while open, flips down when folded */
+  transform: translateY(1px) rotate(-135deg);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.demo-panel[data-expanded='false'] .panel-toggle-chevron {
+  transform: translateY(-1px) rotate(45deg);
+}
+
+.demo-panel-body {
+  /* viewport minus the panel's own top/bottom inset and its header bar */
+  max-height: calc(100dvh - 6rem);
+  overflow: hidden;
+  transition: max-height 0.34s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.22s ease;
+}
+
+.demo-panel[data-expanded='true'] .demo-panel-body {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.demo-panel[data-expanded='false'] .demo-panel-body {
+  max-height: 0;
+  opacity: 0;
+}
+
+.demo-panel-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 0.9rem 0.85rem 1rem;
+}
+
+.demo-panel-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.demo-kicker {
+  font-family: var(--mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
 }
 
 .demo-panel h2 {
-  margin: 0;
+  margin: 0.15rem 0 0;
   font-size: 1.15rem;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
 }
 
 .demo-author {
-  margin: 0.15rem 0 0;
+  margin: 0.2rem 0 0;
   font-family: var(--mono);
-  font-size: 0.82rem;
+  font-size: 0.8rem;
   color: var(--text-dim);
 }
 
 .demo-author a {
   color: var(--text-dim);
   text-decoration: underline;
+}
+
+.demo-ref {
+  margin: 0;
 }
 
 .demo-ref-thumb {
@@ -707,19 +1024,40 @@ code,
   display: block;
 }
 
+.demo-ref figcaption {
+  margin-top: 0.4rem;
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  text-align: center;
+}
+
 .demo-meta {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  font-size: 0.85rem;
+  gap: 0.55rem;
+  font-size: 0.84rem;
+  line-height: 1.55;
   color: var(--text-dim);
+}
+
+.demo-meta p {
+  margin: 0;
 }
 
 .demo-links {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  margin-top: 0.4rem;
+  margin-top: 0.1rem;
+}
+
+.demo-links .btn {
+  justify-content: center;
+  font-size: 0.82rem;
+  padding: 0.65rem 0.9rem;
 }
 
 /* Explode toggle: a <button> in a list of <a class="btn">, so it needs the resets an
@@ -924,19 +1262,153 @@ code,
 
 .hint {
   position: absolute;
-  bottom: 1rem;
+  bottom: max(1rem, env(safe-area-inset-bottom));
   right: 1rem;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   font-family: var(--mono);
   font-size: 0.75rem;
+  white-space: nowrap;
   color: var(--text-dim);
   background: rgba(16, 17, 22, 0.7);
   padding: 0.35rem 0.6rem;
-  border-radius: 6px;
+  border-radius: 999px;
   border: 1px solid var(--border);
+  backdrop-filter: blur(6px);
+  transition: opacity 0.5s ease;
 }
 
-@media (max-width: 640px) {
+.hint.is-gone {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.hint-touch {
+  display: none;
+}
+
+/* Touch devices get the gesture wording that actually applies. */
+@media (hover: none) {
+  .hint-pointer {
+    display: none;
+  }
+  .hint-touch {
+    display: inline;
+  }
+}
+
+/* --- compact viewports: fold the description away so it can't cover the model --- */
+
+@media (max-width: 860px), (max-height: 520px) {
+  .back-text {
+    display: none;
+  }
+  /* The bar carries the title in both states, so the body header doesn't repeat it. */
+  .demo-bar-title {
+    display: block;
+    font-size: 0.95rem;
+  }
+  .demo-panel h2 {
+    display: none;
+  }
+  .demo-panel-head {
+    gap: 0.25rem;
+  }
+  .panel-toggle-label {
+    display: none;
+  }
+  .panel-toggle {
+    padding: 0.45rem 0.6rem;
+  }
+  /* the hint is a single-line pill here — this clause alone is wider than the screen */
+  .hint-extra {
+    display: none;
+  }
+  /* Let the sheet do the scrolling: a nested scroller inside it steals the pan gesture. */
+  .parts-scroll {
+    max-height: none;
+    overflow: visible;
+  }
+}
+
+/* Phone portrait / small tablet: bottom sheet, thumb-reachable, model gets the full screen. */
+@media (max-width: 860px) and (min-height: 521px) {
   .demo-panel {
-    width: calc(100vw - 2rem);
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    border-radius: 18px 18px 0 0;
+    border-left: 0;
+    border-right: 0;
+    border-bottom: 0;
+    padding-bottom: env(safe-area-inset-bottom);
+    box-shadow: 0 -18px 50px rgba(0, 0, 0, 0.55);
+  }
+
+  /* grab-handle affordance */
+  .demo-panel::before {
+    content: '';
+    flex: 0 0 auto;
+    width: 38px;
+    height: 4px;
+    margin: 0.5rem auto 0;
+    border-radius: 2px;
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  .demo-panel-bar {
+    padding: 0.6rem 0.9rem 0.7rem;
+    cursor: pointer;
+  }
+
+  .demo-panel-body {
+    max-height: 52dvh;
+  }
+
+  .demo-panel-inner {
+    padding: 0.9rem 0.95rem 1.4rem;
+  }
+
+  .demo-ref-thumb {
+    max-height: 22dvh;
+    object-fit: cover;
+  }
+
+  /* fade the cut-off edge so it reads as "scroll for more", not "clipped" */
+  .demo-panel[data-expanded='true']::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 1.8rem;
+    background: linear-gradient(to top, rgba(16, 17, 22, 0.96), transparent);
+    pointer-events: none;
+  }
+
+  /* clear of the collapsed sheet */
+  .hint {
+    right: auto;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: calc(4.6rem + env(safe-area-inset-bottom));
+    font-size: 0.7rem;
+  }
+}
+
+/* Phone landscape / short window: stay a side column, there is no vertical room for a sheet. */
+@media (max-height: 520px) {
+  .demo-panel {
+    width: min(300px, 54vw);
+  }
+  .demo-panel-body {
+    max-height: calc(100dvh - 5.5rem);
+  }
+  .demo-ref {
+    display: none;
   }
 }


### PR DESCRIPTION
Mobile currently cannot see the models at all, and the lobby layout breaks. Desktop is deliberately left pixel-identical.

## Root cause

`PerspectiveCamera.fov` is **vertical**, so a narrow viewport shrinks the *horizontal* field of view. The per-demo cameras were art-directed for a wide desktop stage (~16:10); at 390x844 (aspect 0.46) the horizontal frame collapses to about a third of its authored width, and wide subjects — bike, shotgun, war-hauler, diorama — fall entirely outside it. The info panel then covered what little was left.

## New `src/framing.ts`

Measures the subject as a **cylinder around the vertical orbit axis through the camera target** — not a sphere, and not the bounding-box centre. A cylinder is what an orbiting camera actually sees, so one distance holds at every azimuth with nothing re-framed per frame; centring on the target preserves the authored composition.

`fitScale()` returns the multiplier on the authored camera distance and is **exactly 1 at or above the reference aspect**, so desktop cannot move. It also measures each demo's *tightness* and carries it over, which matters because several demos crop on purpose (war-hauler, shotgun, and both new CS2 demos): they stay cropped in the same proportion instead of being "corrected" into a wider shot.

Details that were load-bearing:
- Shadow-catcher planes are excluded from the bounds (`m9-doppler` carries a 20x20 one, the `Viewer` a 30x30). Counting them shrinks the subject to a speck.
- `camera.far` **and** `scene.fog` scale with the pull-back. `warhauler` sets `Fog(11, 26)`; dollying back without scaling fog fades the model to nothing.
- Capture mode (`?capture=1`) skips the fit entirely, so Divine Eye evaluation frames stay deterministic — verified unchanged.

## Integration with the new explode / part inspector (#15)

`applyExplode()` and the focus easing also own the camera distance. Two real conflicts, both fixed:
- On resize, `applyFit` reads the current distance as "user zoom". While exploded that distance is inflated up to 3.4x, so the explode dolly got folded into the framing and the camera was left stranded once the animation settled. `applyFit` now yields while `explodeT`/`explodeTarget`/`camGoal` are active.
- `explodeBaseDist` / `camRest.dist` / `camGoal.dist` are re-based by the framing ratio, so an explode or focus starting across a resize dollies from the right distance instead of snapping to the pre-resize one.

`.demo-parts` and the Explode button now live **inside** the collapsible sheet — otherwise mobile got a second full-width panel over the model. `.parts-scroll` drops its nested scroller on compact (it stole the pan gesture from the sheet).

## Collapsible info sheet

- Phone portrait: bottom sheet, **collapsed by default** so the model owns the screen. Bar shows back + title + chevron; tapping anywhere on the bar toggles. Grab handle, internal scroll, bottom fade.
- Phone landscape / short window (`max-height: 520px`): stays a side column — a sheet has no vertical room there — and drops the reference thumb.
- Desktop: unchanged card plus a `DETAILS` toggle. It also fixes an existing bug where the panel overflowed and clipped both buttons mid-glyph.
- State persists across demos; an untouched panel re-defaults when the viewport crosses the breakpoint.

## Lobby

Nav wraps and sheds its longest label instead of breaking to two lines; hero stage gets aspect-aware framing (reference 1.11 = the desktop stage aspect) plus 12% extra room on phones, keyed to `innerWidth` so the 508px-wide desktop stage is untouched; demo-title badge became a full-width ellipsised strip so it stops colliding with the corner hint; source-photo inset 118px -> 72px; grid uses `minmax(min(270px, 100%), 1fr)`; hover-lift wrapped in `@media (hover: hover)` so it stops sticking after a tap; `100dvh`, safe-area insets, `touch-action: none` on the canvas.

## Also fixed

The hero stage leaked `scene.fog` between demos — `warhauler` set it and every demo after inherited it.

## Verified

`tsc --noEmit` clean, `vite build` passes, `check-showcase-safety` passes, 0 console errors.

Screenshotted at 320 / 390 / 768 / 844x390 landscape / 1440 across all 10 demos. Desktop framing compared against baseline captures and is unchanged. Explode -> rotate -> assemble returns to the exact initial mobile framing with no drift.

## One judgement call for review

`glock-ghost-protocol` is framed as a tight macro crop **on desktop too** (slide runs off both edges, grip cut off). The tightness rule reproduces that crop proportionally on mobile rather than overriding your art direction, so it still reads as cropped there — consistent with desktop, but if you would rather narrow viewports always show the whole subject, that is a one-line clamp in `fitScale` and I am happy to add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)