### PR TITLE
fix(donate): update license tag from MIT to Apache 2.0

### DIFF
--- a/public/donate.html
+++ b/public/donate.html
@@ -190,7 +190,7 @@
     </div>
 
     <main class="wrap">
-      <span class="tag reveal d1">// open-source · MIT<span class="cursor">&nbsp;</span></span>
+      <span class="tag reveal d1">// open-source · Apache 2.0<span class="cursor">&nbsp;</span></span>
       <h1 class="reveal d1">Support img2threejs</h1>
       <p class="lead reveal d2">
         Thanks for using img2threejs! If it saved you time, a small tip helps keep the


### PR DESCRIPTION
The project relicensed to Apache 2.0, but the donate page still advertised MIT.

- `public/donate.html` — the header tag now reads `// open-source · Apache 2.0`

Single-line content change, no styling or layout impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)