### PR TITLE
docs: add Buy Me a Coffee support option

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ you rebuilt this weekend?
 - **`#wishlist`** — what categories people actually want next, beyond the current 14 exhibits
 - **`#i-made-a-thing`** — share models built with the skill, whether or not they ship to the gallery
 
+## Support the project
+
+img2threejs is free and open source. If the gallery or the underlying skill saved you time, consider
+supporting continued development:
+
+<a href="https://www.buymeacoffee.com/hoainhowors" target="_blank" rel="noopener noreferrer"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+
+VietQR / MoMo / PayPal also work — see the [donate page](https://hoainho.github.io/img2threejs-showcase/donate.html).
+
 ## Star History
 
 <a href="https://www.star-history.com/#hoainho/img2threejs-showcase&Timeline">

--- a/public/donate.html
+++ b/public/donate.html
@@ -217,6 +217,10 @@
         <a class="paypal" href="https://www.paypal.com/paypalme/NguyenHoai545" target="_blank" rel="noopener noreferrer">
           Donate via PayPal
         </a>
+
+        <a href="https://www.buymeacoffee.com/hoainhowors" target="_blank" rel="noopener noreferrer" style="display: inline-block; margin-top: .75rem;">
+          <img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me a Coffee" style="height: 48px; width: 174px; display: block;" />
+        </a>
       </section>
 
       <footer class="reveal d4">


### PR DESCRIPTION
## Summary
- Added a Buy Me a Coffee button to public/donate.html alongside the existing MoMo/VietQR and PayPal options.
- Added a "Support the project" section to README.md linking the same button and the donate page.

## Test plan
- [ ] Open donate.html locally/deployed and confirm the new button renders and links to buymeacoffee.com/hoainhowors.