### PR TITLE
fix: align PayPal and Buy Me a Coffee buttons 50/50 on donate page

### DIFF
--- a/public/donate.html
+++ b/public/donate.html
@@ -162,15 +162,27 @@
       }
       .divider::before, .divider::after { content: ""; flex: 1; height: 1px; background: var(--line); }
 
+      .support-row { display: flex; gap: .6rem; margin-top: 1.4rem; }
+      @media (max-width: 360px) { .support-row { flex-direction: column; } }
+
       .paypal {
         display: inline-flex; align-items: center; justify-content: center; gap: .5rem;
-        width: 100%; padding: .75rem 1.25rem; border-radius: 12px;
+        flex: 1 1 0; padding: .75rem 1rem; border-radius: 12px;
         font-weight: 700; font-size: .95rem; text-decoration: none;
         color: #fff; background: linear-gradient(135deg, var(--accent), var(--accent-2));
         box-shadow: 0 10px 26px -10px var(--qr-shadow);
         transition: transform .25s cubic-bezier(.2,.7,.2,1), box-shadow .25s ease;
       }
       .paypal:hover { transform: translateY(-2px); box-shadow: 0 14px 30px -10px var(--qr-shadow); }
+
+      .bmc {
+        flex: 1 1 0; display: flex; align-items: center; justify-content: center;
+        border-radius: 12px; background: #fff; padding: .35rem;
+        box-shadow: 0 10px 26px -10px var(--qr-shadow);
+        transition: transform .25s cubic-bezier(.2,.7,.2,1), box-shadow .25s ease;
+      }
+      .bmc:hover { transform: translateY(-2px); box-shadow: 0 14px 30px -10px var(--qr-shadow); }
+      .bmc img { height: 44px; width: auto; max-width: 100%; display: block; }
 
       footer { margin-top: 2rem; font-family: var(--mono); font-size: .85rem; color: var(--muted); }
       footer a { color: var(--accent); text-decoration: none; font-weight: 600; }
@@ -214,13 +226,14 @@
 
         <div class="divider"><span>or</span></div>
 
-        <a class="paypal" href="https://www.paypal.com/paypalme/NguyenHoai545" target="_blank" rel="noopener noreferrer">
-          Donate via PayPal
-        </a>
-
-        <a href="https://www.buymeacoffee.com/hoainhowors" target="_blank" rel="noopener noreferrer" style="display: inline-block; margin-top: .75rem;">
-          <img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me a Coffee" style="height: 48px; width: 174px; display: block;" />
-        </a>
+        <div class="support-row">
+          <a class="paypal" href="https://www.paypal.com/paypalme/NguyenHoai545" target="_blank" rel="noopener noreferrer">
+            Donate via PayPal
+          </a>
+          <a class="bmc" href="https://www.buymeacoffee.com/hoainhowors" target="_blank" rel="noopener noreferrer">
+            <img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me a Coffee" />
+          </a>
+        </div>
       </section>
 
       <footer class="reveal d4">


### PR DESCRIPTION
## Summary
- The PayPal and Buy Me a Coffee buttons were stacked (full-width bar + a smaller left-aligned button below).
- Wrapped both in a flex row (`.support-row`) so they sit side by side, evenly split 50/50, matching height and corner radius.
- Falls back to stacked on very narrow screens (<360px) so text doesn't get cramped.

## Test plan
- [x] Verified locally in light and dark mode via a static preview — both buttons render side by side, equal width, equal height.