### PR TITLE
perf(showcase): stop the hero stage blocking the main thread

### DIFF
--- a/src/demos/low-poly-humanoid/createLowPolyHumanoidModel.ts
+++ b/src/demos/low-poly-humanoid/createLowPolyHumanoidModel.ts
@@ -1182,28 +1182,72 @@ function sdPlate(
   return outside + inside - plate.round;
 }
 
-function evaluateField(capsules: Capsule[], x: number, y: number, z: number): number {
-  let d = Infinity;
-  for (const raw of capsules) {
+/**
+ * A capsule with every per-sample-invariant term already folded in.
+ *
+ * WHY THIS TYPE EXISTS AT ALL. `evaluateField` runs once per capsule per grid sample, and the body
+ * grid is 225 x 145 x 65 = 2.12M samples against 92 capsules — 195M iterations. The radius scale,
+ * the squash lookup and the pre-scaled endpoints are all constant across every one of them, so
+ * computing them inside the loop is 195M redundant evaluations AND 195M short-lived objects.
+ * Hoisting them into a prepared list is the whole difference between a page that paints and a page
+ * that blocks the main thread for tens of seconds.
+ */
+type PreparedCapsule = {
+  a: [number, number, number];
+  b: [number, number, number];
+  ra: number;
+  rb: number;
+  sx: number; sy: number; sz: number;
+  /** Endpoints already multiplied by the squash, for the symmetric path. */
+  asx: number; asy: number; asz: number;
+  bsx: number; bsy: number; bsz: number;
+  bias?: [number, number];
+  plate?: Capsule['plate'];
+  k: number;
+  carve: boolean;
+};
+
+/** Folds the radius scale and squash into each capsule once, ahead of any sampling. */
+function prepareField(capsules: Capsule[]): PreparedCapsule[] {
+  return capsules.map((raw) => {
     const s = raw.exact ? 1 : BODY_RADIUS_SCALE;
-    const c = { ...raw, ra: raw.ra * s, rb: raw.rb * s };
-    const sx = c.squash ? c.squash[0] : 1;
-    const sy = c.squash ? c.squash[1] : 1;
-    const sz = c.squash ? c.squash[2] : 1;
+    const sx = raw.squash ? raw.squash[0] : 1;
+    const sy = raw.squash ? raw.squash[1] : 1;
+    const sz = raw.squash ? raw.squash[2] : 1;
+    return {
+      a: raw.a,
+      b: raw.b,
+      ra: raw.ra * s,
+      rb: raw.rb * s,
+      sx, sy, sz,
+      asx: raw.a[0] * sx, asy: raw.a[1] * sy, asz: raw.a[2] * sz,
+      bsx: raw.b[0] * sx, bsy: raw.b[1] * sy, bsz: raw.b[2] * sz,
+      bias: raw.bias,
+      plate: raw.plate,
+      k: raw.k,
+      carve: raw.op === 'carve',
+    };
+  });
+}
+
+function evaluateField(capsules: PreparedCapsule[], x: number, y: number, z: number): number {
+  let d = Infinity;
+  for (let i = 0; i < capsules.length; i += 1) {
+    const c = capsules[i];
     // The asymmetric path runs only when `bias` is set, so every capsule authored before it keeps
     // its exact previous value. It also scales the offset AFTER projection rather than scaling the
     // sample point, which is what keeps the axis where it was put.
     const v = c.plate
       ? sdPlate(x, y, z, c.a, c.plate)
       : c.bias
-      ? sdCapsuleBiased(x, y, z, c.a, c.b, c.ra, c.rb, sx, sy, sz, c.bias[0], c.bias[1])
+      ? sdCapsuleBiased(x, y, z, c.a, c.b, c.ra, c.rb, c.sx, c.sy, c.sz, c.bias[0], c.bias[1])
       : sdCapsule(
-        x * sx, y * sy, z * sz,
-        c.a[0] * sx, c.a[1] * sy, c.a[2] * sz,
-        c.b[0] * sx, c.b[1] * sy, c.b[2] * sz,
+        x * c.sx, y * c.sy, z * c.sz,
+        c.asx, c.asy, c.asz,
+        c.bsx, c.bsy, c.bsz,
         c.ra, c.rb,
       );
-    if (c.op === 'carve') d = smax(d, -v, c.k);
+    if (c.carve) d = smax(d, -v, c.k);
     else d = d === Infinity ? v : smin(d, v, c.k);
   }
   return d;
@@ -1236,8 +1280,11 @@ const CROTCH_SLIT: Capsule[] = [
   { a: [0, 2.70, -0.12], b: [0, 2.16, -0.12], ra: 0.070, rb: 0.086, squash: [1, 1, 0.055], k: 0.015, op: 'carve', exact: true },
 ];
 
+/** Prepared once at module load — see `PreparedCapsule`. Rebuilding it per sample cost 2.12M arrays. */
+const BODY_FIELD = prepareField([...BODY_CAPSULES, ...CROTCH_SLIT]);
+
 function bodyField(x: number, y: number, z: number): number {
-  return evaluateField([...BODY_CAPSULES, ...CROTCH_SLIT], x, y, z);
+  return evaluateField(BODY_FIELD, x, y, z);
 }
 
 /**
@@ -1250,8 +1297,10 @@ function bodyField(x: number, y: number, z: number): number {
  * vertices of the same ring, and it read exactly as what it is: a dent pulled into the centre of the
  * crotch. The legs still use the slit-cut field, because a leg does wrap its own inner wall.
  */
+const BODY_FIELD_NO_SLIT = prepareField(BODY_CAPSULES);
+
 function bodyFieldNoSlit(x: number, y: number, z: number): number {
-  return evaluateField(BODY_CAPSULES, x, y, z);
+  return evaluateField(BODY_FIELD_NO_SLIT, x, y, z);
 }
 
 
@@ -1264,6 +1313,124 @@ function bodyFieldNoSlit(x: number, y: number, z: number): number {
  * is the right output for a low-poly read. The vertex placement also rounds the result slightly,
  * which suits an organic body better than marching cubes' faceted output.
  */
+/**
+ * Scalar field grids, keyed by the polygonisation they belong to.
+ *
+ * The grid is READ-ONLY once filled — the surface-nets pass only reads it — and the field it comes
+ * from is a pure function of module-level capsule tables, so the same key always describes the same
+ * numbers. That is what makes it safe to fill the grid somewhere other than inside
+ * `polygonizeField`, which is the whole point: it lets the ~4s of sampling be paid a few
+ * milliseconds at a time between animation frames instead of in one blocking call.
+ */
+const fieldGrids = new Map<string, Float32Array>();
+
+const gridKey = (name: string, nx: number, ny: number, nz: number): string =>
+  `${name}|${nx}x${ny}x${nz}`;
+
+/** Walks the grid, calling `visit` per row, so the sync and sliced paths cannot diverge. */
+function eachGridRow(
+  field: (x: number, y: number, z: number) => number,
+  min: [number, number, number],
+  max: [number, number, number],
+  nx: number, ny: number, nz: number,
+  grid: Float32Array,
+): (j: number, k: number) => void {
+  const dx = (max[0] - min[0]) / nx, dy = (max[1] - min[1]) / ny, dz = (max[2] - min[2]) / nz;
+  const gi = (i: number, j: number, k: number): number => (k * (ny + 1) + j) * (nx + 1) + i;
+  return (j, k) => {
+    const y = min[1] + j * dy;
+    const z = min[2] + k * dz;
+    for (let i = 0; i <= nx; i += 1) grid[gi(i, j, k)] = field(min[0] + i * dx, y, z);
+  };
+}
+
+/** The grid for this polygonisation, sampling it synchronously if nothing has pre-warmed it. */
+function fieldGrid(
+  name: string,
+  field: (x: number, y: number, z: number) => number,
+  min: [number, number, number],
+  max: [number, number, number],
+  nx: number, ny: number, nz: number,
+): Float32Array {
+  const key = gridKey(name, nx, ny, nz);
+  const cached = fieldGrids.get(key);
+  if (cached) return cached;
+  const grid = new Float32Array((nx + 1) * (ny + 1) * (nz + 1));
+  const row = eachGridRow(field, min, max, nx, ny, nz, grid);
+  for (let k = 0; k <= nz; k += 1) for (let j = 0; j <= ny; j += 1) row(j, k);
+  fieldGrids.set(key, grid);
+  return grid;
+}
+
+/** Hands the main thread back, preferring a frame boundary but still progressing in a hidden tab. */
+function yieldToBrowser(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === 'function'
+      && (typeof document === 'undefined' || document.visibilityState !== 'hidden')) {
+      requestAnimationFrame(() => resolve());
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
+/**
+ * Fills a field grid a slice at a time, yielding to the browser between slices.
+ *
+ * `sliceMs` is a budget, not a row count, because a row's cost is not knowable ahead of time — it
+ * depends on how many capsules the row passes near. Sampling one row is around half a millisecond,
+ * so the budget is honoured to well inside a frame.
+ */
+async function sampleFieldGrid(
+  name: string,
+  field: (x: number, y: number, z: number) => number,
+  min: [number, number, number],
+  max: [number, number, number],
+  [nx, ny, nz]: [number, number, number],
+  sliceMs = 4,
+): Promise<void> {
+  const key = gridKey(name, nx, ny, nz);
+  if (fieldGrids.has(key)) return;
+  const grid = new Float32Array((nx + 1) * (ny + 1) * (nz + 1));
+  const row = eachGridRow(field, min, max, nx, ny, nz, grid);
+  let j = 0;
+  let k = 0;
+  while (k <= nz) {
+    const deadline = performance.now() + sliceMs;
+    do {
+      row(j, k);
+      j += 1;
+      if (j > ny) { j = 0; k += 1; }
+    } while (k <= nz && performance.now() < deadline);
+    if (k <= nz) await yieldToBrowser();
+  }
+  // Published only once complete, so a build racing the prewarm never sees a half-filled grid.
+  fieldGrids.set(key, grid);
+}
+
+/** Geometry of the body polygonisation — kept beside the call in `createLowPolyHumanoidModel`. */
+const BODY_FIELD_GRID = {
+  name: 'Continuous body surface',
+  min: [-3.55, -0.06, -0.9] as [number, number, number],
+  max: [3.55, 5.85, 0.9] as [number, number, number],
+  resolution: [224, 144, 64] as [number, number, number],
+};
+
+/**
+ * Pays for the body's signed-distance grid off the critical path.
+ *
+ * `createLowPolyHumanoidModel` is synchronous and stays that way — callers that do not care can
+ * ignore this and pay the cost inline. Awaiting it first makes the subsequent build ~30x cheaper,
+ * which is the difference between the hero stage blocking every input for four seconds and not
+ * blocking at all.
+ */
+export function prewarmLowPolyHumanoidField(): Promise<void> {
+  return sampleFieldGrid(
+    BODY_FIELD_GRID.name, bodyField, BODY_FIELD_GRID.min, BODY_FIELD_GRID.max,
+    BODY_FIELD_GRID.resolution,
+  );
+}
+
 function polygonizeField(
   name: string,
   field: (x: number, y: number, z: number) => number,
@@ -1301,17 +1468,13 @@ function polygonizeField(
   const [nx, ny, nz] = typeof resolution === 'number'
     ? [resolution, resolution, resolution] : resolution;
   const dx = (max[0] - min[0]) / nx, dy = (max[1] - min[1]) / ny, dz = (max[2] - min[2]) / nz;
-  const at = (i: number, j: number, k: number): number =>
-    field(min[0] + i * dx, min[1] + j * dy, min[2] + k * dz);
-
-  // One scalar sample per grid corner, computed once.
-  const grid = new Float32Array((nx + 1) * (ny + 1) * (nz + 1));
   const gi = (i: number, j: number, k: number): number => (k * (ny + 1) + j) * (nx + 1) + i;
-  for (let k = 0; k <= nz; k += 1) {
-    for (let j = 0; j <= ny; j += 1) {
-      for (let i = 0; i <= nx; i += 1) grid[gi(i, j, k)] = at(i, j, k);
-    }
-  }
+
+  // One scalar sample per grid corner, computed once — and it is the whole cost of this function.
+  // Sampling the body's 225 x 145 x 65 corners against 92 capsules is ~195M field evaluations; the
+  // surface-nets pass that follows reads the result and is a rounding error beside it. See
+  // `sampleFieldGrid` for why that matters and who else fills this cache.
+  const grid = fieldGrid(name, field, min, max, nx, ny, nz);
 
   const vertexAt = new Int32Array(nx * ny * nz).fill(-1);
   const ci = (i: number, j: number, k: number): number => (k * ny + j) * nx + i;
@@ -4797,8 +4960,10 @@ export function createLowPolyHumanoidModel(
     root,
     root,
     'body',
-    polygonizeField('Continuous body surface', bodyField, [-3.55, -0.06, -0.9], [3.55, 5.85, 0.9],
-      [224, 144, 64], skin, insideTorsoShell),
+    // Bounds and resolution come from `BODY_FIELD_GRID` so this call and the prewarm cannot drift
+    // onto different grids — a mismatch would silently miss the cache and block for four seconds.
+    polygonizeField(BODY_FIELD_GRID.name, bodyField, BODY_FIELD_GRID.min, BODY_FIELD_GRID.max,
+      BODY_FIELD_GRID.resolution, skin, insideTorsoShell),
     'root',
     'body',
     runtime,
@@ -6045,7 +6210,30 @@ export function createLowPolyHumanoidModel(
     // Taking the camera's position IN THE HEAD'S LOCAL FRAME covers both cases with one expression:
     // it changes when the character turns AND when the viewer orbits, which is the same relative
     // motion and the thing a viewer actually perceives as the character turning.
-    hairMassMesh.onBeforeRender = (_r, _s, camera): void => {
+    // ONCE PER FRAME, NOT ONCE PER DRAW.
+    //
+    // `onBeforeRender` is a PER-DRAW hook, and this mesh is drawn many times per animation frame —
+    // once per material group, plus once more for every shadow pass it takes part in. Measured on
+    // the hero turntable it fired about 93 times per frame, so the spring integrated 93 sub-steps
+    // and, far worse, `computeVertexNormals` ran 93 times over the same 883 vertices. That was
+    // ~8,400 normal rebuilds per second and it pinned the hero stage in single-digit fps for as
+    // long as this demo was on the turntable.
+    //
+    // `dt <= 0` was meant to be this guard and cannot be: `performance.now()` is sub-millisecond, so
+    // it advances between two draws of the SAME frame and every redundant call saw a positive dt.
+    // The renderer's own frame counter is the thing that actually distinguishes them — it does not
+    // change within a single `render()` call.
+    //
+    // The sub-steps were not free accuracy either. The camera only moves between frames, so draws
+    // 2..93 fed the impulse term a zero delta while still applying damping, which over-damped the
+    // spring against its own authored STIFF/DAMP. One step per frame is the motion those constants
+    // were tuned for.
+    let lastFrame = -1;
+    hairMassMesh.onBeforeRender = (renderer, _s, camera): void => {
+      const frame = renderer.info.render.frame;
+      if (frame === lastFrame) return;
+      lastFrame = frame;
+
       const now = performance.now() / 1000;
       const dt = prevT ? Math.min(0.05, now - prevT) : 0;
       prevT = now;

--- a/src/demos/registry.ts
+++ b/src/demos/registry.ts
@@ -61,6 +61,7 @@ import {
 import {
   createLowPolyHumanoidLookDevLights,
   createLowPolyHumanoidModel,
+  prewarmLowPolyHumanoidField,
 } from './low-poly-humanoid/createLowPolyHumanoidModel';
 
 export interface DemoEntry {
@@ -108,6 +109,15 @@ export interface DemoEntry {
   installLights?: (scene: THREE.Scene) => void;
   /** Adds the model (and any demo-specific lights) to the scene, returns the group. */
   build: (scene: THREE.Scene) => THREE.Group;
+  /**
+   * Precomputes this demo's expensive intermediates, yielding to the browser as it goes.
+   *
+   * `build` is synchronous by contract and every caller may keep treating it that way. This is for
+   * demos whose build is heavy enough to be felt as a frozen page — awaiting it first moves that
+   * cost off the critical path, after which `build` is cheap. Resolving twice is a no-op, and the
+   * result is cached for the lifetime of the module, so any later `build` is fast too.
+   */
+  prewarm?: () => Promise<void>;
   /** Optional deterministic capture framing margin for source plates with tight bounds. */
   captureMargin?: number;
   /** Optional vertical framing correction as a fraction of the measured subject bbox height. */
@@ -161,6 +171,8 @@ export const demos: DemoEntry[] = [
     installLights: (scene) => {
       scene.add(createLowPolyHumanoidLookDevLights('reference'));
     },
+    // The only demo heavy enough to need this: its body is a 2.12M-sample signed-distance field.
+    prewarm: prewarmLowPolyHumanoidField,
     build: (scene) => {
       const group = createLowPolyHumanoidModel({ castShadow: true, receiveShadow: true });
       scene.add(group);

--- a/src/hero-stage.ts
+++ b/src/hero-stage.ts
@@ -42,6 +42,26 @@ export class HeroStage {
   private fogBase: { near: number; far: number } | null = null;
 
   private activeObjects: THREE.Object3D[] = [];
+  /**
+   * Every demo this stage has built, kept alive and merely hidden when it is not on the turntable.
+   *
+   * The turntable used to dispose the active model and call `build` again on every swap, so the
+   * cost of a demo was paid once per 5.2s cycle AND once per card hover, forever. Most demos build
+   * in ~10ms and that was invisible; the procedural humanoid builds a 2.1M-sample signed-distance
+   * field, so the same code path froze the page every time it came round. Caching turns a swap into
+   * a `visible` toggle, which is what the turntable always looked like it was doing.
+   */
+  private readonly built = new Map<number, {
+    objects: THREE.Object3D[];
+    fog: THREE.Fog | null;
+    fogBase: { near: number; far: number } | null;
+    fitExtent: SubjectExtent | null;
+  }>();
+  private started = false;
+  /** Demo indices the turntable may show — everything without a `prewarm`, plus each one as it lands. */
+  private readonly ready = new Set<number>();
+  /** Late arrivals awaiting their first turn, so a pre-warmed demo is not held back a full lap. */
+  private readonly pendingDebut: number[] = [];
   private index = -1;
   private elapsed = 0;
   private entryStart = 0;
@@ -172,31 +192,50 @@ export class HeroStage {
     }
   }
 
-  private clearActive(): void {
-    for (const obj of this.activeObjects) {
-      this.scene.remove(obj);
-      obj.traverse((node) => {
-        const mesh = node as THREE.Mesh;
-        mesh.geometry?.dispose();
-        const material = mesh.material as THREE.Material | THREE.Material[] | undefined;
-        if (!material) return;
-        for (const mat of Array.isArray(material) ? material : [material]) mat.dispose();
-      });
-    }
-    this.activeObjects = [];
+  private static disposeObject(obj: THREE.Object3D): void {
+    obj.traverse((node) => {
+      const mesh = node as THREE.Mesh;
+      mesh.geometry?.dispose();
+      const material = mesh.material as THREE.Material | THREE.Material[] | undefined;
+      if (!material) return;
+      for (const mat of Array.isArray(material) ? material : [material]) mat.dispose();
+    });
   }
 
   private showDemo(index: number): void {
-    this.clearActive();
+    for (const obj of this.activeObjects) obj.visible = false;
+
     const demo = this.demos[index];
-    const before = new Set(this.scene.children);
-    // Reset fog so a previous demo's atmosphere doesn't leak onto this one.
-    this.scene.fog = null;
-    demo.build(this.scene);
-    // Some demos set an opaque scene.background; keep the hero canvas transparent
-    // so the CSS aurora shows through.
-    this.scene.background = null;
-    this.activeObjects = this.scene.children.filter((c) => !before.has(c));
+    let entry = this.built.get(index);
+    if (!entry) {
+      const before = new Set(this.scene.children);
+      // Reset fog so a previous demo's atmosphere doesn't leak onto this one.
+      this.scene.fog = null;
+      demo.build(this.scene);
+      // Some demos set an opaque scene.background; keep the hero canvas transparent
+      // so the CSS aurora shows through.
+      this.scene.background = null;
+      const objects = this.scene.children.filter((c) => !before.has(c));
+      // Cast because TS narrows `scene.fog` to `null` from the reset above — it cannot see that
+      // `demo.build` is what puts a fog back.
+      const built = this.scene.fog as THREE.Fog | null;
+      const fog = built instanceof THREE.Fog ? built : null;
+      // `fogBase` and `fitExtent` are captured HERE, before `applyFit` runs, because `applyFit`
+      // mutates `fog.near`/`fog.far` in place and the entry animation mutates the model's scale.
+      // Re-deriving either of them on a later show would read a value this class had already
+      // scaled, and the demo would drift a little further every time it came round.
+      entry = {
+        objects,
+        fog,
+        fogBase: fog ? { near: fog.near, far: fog.far } : null,
+        fitExtent: null,
+      };
+      this.built.set(index, entry);
+    } else {
+      for (const obj of entry.objects) obj.visible = true;
+    }
+    this.scene.fog = entry.fog;
+    this.activeObjects = entry.objects;
 
     const [tx, ty, tz] = demo.cameraTarget;
     const [px, py, pz] = demo.cameraPosition;
@@ -210,9 +249,9 @@ export class HeroStage {
     this.camera.fov = demo.cameraFov;
     this.camera.updateProjectionMatrix();
 
-    this.fitExtent = subjectExtent(this.activeObjects, this.target);
-    const fog = this.scene.fog as THREE.Fog | null;
-    this.fogBase = fog instanceof THREE.Fog ? { near: fog.near, far: fog.far } : null;
+    if (!entry.fitExtent) entry.fitExtent = subjectExtent(this.activeObjects, this.target);
+    this.fitExtent = entry.fitExtent;
+    this.fogBase = entry.fogBase;
     this.applyFit();
 
     this.entryStart = this.elapsed;
@@ -220,13 +259,58 @@ export class HeroStage {
     this.onDemo(demo, index);
   }
 
+  /**
+   * The next demo whose `prewarm` has finished, searching forward and wrapping.
+   *
+   * A demo that declares `prewarm` is one whose `build` would block long enough to be felt, so it
+   * is not eligible for the turntable until that work is done. Returns the current index when
+   * nothing else is ready yet, which simply holds the current demo on screen a little longer.
+   */
+  private nextReady(from: number): number {
+    const n = this.demos.length;
+    for (let step = 1; step <= n; step += 1) {
+      const i = (from + step) % n;
+      if (this.ready.has(i)) return i;
+    }
+    return from;
+  }
+
   private next(): void {
-    this.showDemo((this.index + 1) % this.demos.length);
+    // A demo that finished pre-warming after the turntable had already passed its slot would
+    // otherwise wait out a whole lap. The humanoid is demo 0 and the reason this page exists, so
+    // giving a late arrival the next slot rather than a 70-second wait is the point of the queue.
+    const debut = this.pendingDebut.shift();
+    if (debut !== undefined && debut !== this.index) {
+      this.showDemo(debut);
+      return;
+    }
+    const i = this.nextReady(this.index);
+    if (i !== this.index) this.showDemo(i);
+  }
+
+  /**
+   * Walks the demos that need pre-warming, one at a time, and admits each to the turntable when it
+   * lands. Sequential rather than concurrent: these are main-thread time slices, so running two at
+   * once would halve the frame budget without finishing either any sooner.
+   */
+  private async prewarmAll(): Promise<void> {
+    for (let i = 0; i < this.demos.length; i += 1) {
+      const prewarm = this.demos[i].prewarm;
+      if (!prewarm || this.ready.has(i)) continue;
+      try {
+        await prewarm();
+      } catch {
+        // A demo that cannot pre-warm stays out of the rotation rather than taking the page down.
+        continue;
+      }
+      if (this.disposed) return;
+      this.ready.add(i);
+      this.pendingDebut.push(i);
+    }
   }
 
   start(): void {
     if (this.demos.length === 0) return;
-    this.showDemo(0);
     const loop = (): void => {
       if (this.disposed) return;
       this.rafHandle = requestAnimationFrame(loop);
@@ -275,11 +359,40 @@ export class HeroStage {
 
       this.composer.render();
     };
-    loop();
+
+    // THE FIRST BUILD MUST NOT BLOCK THE FIRST PAINT. `renderHome` sets the page's markup and
+    // constructs this stage in one synchronous task, so a `showDemo(0)` called inline runs before
+    // the browser has painted anything: the nav, hero copy and the whole card grid stay invisible
+    // for as long as the heaviest demo takes to build. Two nested frames is the cheap guarantee
+    // that a paint has actually happened — one rAF fires BEFORE the paint it is scheduled against,
+    // not after. The turntable then starts a beat late, which nobody can see, instead of the page
+    // arriving late, which everybody can.
+    for (let i = 0; i < this.demos.length; i += 1) {
+      if (!this.demos[i].prewarm) this.ready.add(i);
+    }
+
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      if (this.disposed) return;
+      // Open on the first demo that needs no pre-warming, rather than always on demo 0. Demo 0 may
+      // be the expensive one, and waiting for it would leave the stage empty for several seconds
+      // while thirteen other demos were ready to orbit. It joins the rotation when it lands.
+      this.showDemo(this.nextReady(this.demos.length - 1));
+      this.started = true;
+      // Discard the build time so the entry animation starts from zero rather than mid-flight.
+      this.clock.getDelta();
+      loop();
+      void this.prewarmAll();
+    }));
   }
 
   /** Jump to a specific demo (e.g. when the user hovers a card). */
   focus(index: number): void {
+    // Hovering a card before the stage has shown its first demo would build a second model ahead of
+    // demo 0 and leave `index` pointing at something the turntable never introduced.
+    if (!this.started) return;
+    // A demo still pre-warming would have to build synchronously to be shown, which is exactly the
+    // multi-second freeze the pre-warm exists to avoid. Hovering it early is a no-op.
+    if (!this.ready.has(index)) return;
     if (index < 0 || index >= this.demos.length || index === this.index) return;
     this.sinceSwap = 0;
     this.showDemo(index);
@@ -289,7 +402,16 @@ export class HeroStage {
     this.disposed = true;
     cancelAnimationFrame(this.rafHandle);
     this.ro.disconnect();
-    this.clearActive();
+    // Every demo ever shown is still in the scene, hidden — dispose all of them, not just the
+    // visible one, or the cache leaks a GPU buffer per demo the user hovered.
+    for (const entry of this.built.values()) {
+      for (const obj of entry.objects) {
+        this.scene.remove(obj);
+        HeroStage.disposeObject(obj);
+      }
+    }
+    this.built.clear();
+    this.activeObjects = [];
     this.scene.traverse((node) => {
       const mesh = node as THREE.Mesh;
       mesh.geometry?.dispose();


### PR DESCRIPTION
## Problem

Landing on `/img2threejs-showcase` froze the page: no UI was interactive for several seconds, and the hero turntable stuttered badly whenever the humanoid was on stage. The freeze also **repeated** — on every 5.2s turntable cycle and on every card hover, indefinitely.

Two independent bugs, both pre-existing on `main`.

## Cause

### A — Main thread blocked for ~30s

**A1. Per-sample allocation in the SDF hot loop.** `polygonizeField` samples 225×145×65 = 2.12M grid corners against 92 capsules. `bodyField` allocated a fresh 92-element array **per sample** via `[...BODY_CAPSULES, ...CROTCH_SLIT]`, and `evaluateField` allocated a fresh object **per capsule per sample** via `{ ...raw, ra: raw.ra * s }` — 2.12M arrays and ~195M objects. CPU profile showed `evaluateField` at 17.9s self time and `bodyField` at 9.4s self time, the latter for a function whose body is a single call, which is pure spread cost.

**A2. The remaining ~4.4s was genuine SDF math.** No allocation left to remove.

**A3. It also blocked first paint.** `renderHome` set the page markup and called `showDemo(0)` in the same synchronous task, so nothing painted until the build finished.

### B — Sustained stutter

**B1. The hair spring ran ~93× per frame.** `onBeforeRender` is a **per-draw** hook and this mesh is drawn many times per animation frame (once per material group, plus shadow passes). Each call ran `computeVertexNormals()` over the same 883 vertices — measured at ~8,400 normal rebuilds per second, pinning the stage at 6 fps. The intended guard, `if (dt <= 0) return`, cannot work: `performance.now()` is sub-millisecond, so it advances between two draws of the same frame.

This also explains why the 5.2s slot stretched to ~20s of wall clock: `dt` is clamped by `Math.min(0.05, …)`, so at 6 fps `sinceSwap` only advances ~300ms per real second.

**B2. Every swap rebuilt from scratch.** `showDemo` disposed the active model and called `build` again, so the cost recurred forever rather than once.

## Solution

| | Change |
|---|---|
| A1 | `prepareField()` folds the radius scale, squash and pre-scaled endpoints into each capsule once at module load |
| A2 | The grid is read-only after filling and the field is pure, so `sampleFieldGrid()` fills it in 4ms slices, yielding between them, and caches the result. `build` stays **synchronous** — a new optional `DemoEntry.prewarm` carries the async work |
| A3 | Double-rAF before the first build (one rAF fires *before* the paint it is scheduled against, so two are needed). The stage opens on a demo that needs no pre-warming; pre-warmed demos join the turntable when ready |
| B1 | `renderer.info.render.frame` as a frame token — it does not change within a single `render()` call |
| B2 | Built demos are cached; a swap toggles `visible` |

## Measurements

Longest main-thread block, and frame rate over a 150s soak:

| | before | after |
|---|---|---|
| longest block | 31,007 ms | **258 ms** |
| total blocking, first 20s | 31,007 ms | **377 ms** |
| humanoid build | 29,653 ms | 4,426 ms → **290 ms** pre-warmed |
| `computeVertexNormals` per frame | 93.3 | **1.0** |
| fps, 0–10s | 62 | **116** |
| fps, 10–150s | 6–120 (collapse at 78–97s) | **114–117, flat** |

Pre-warming takes 8.6s of wall clock at a steady 120 fps (1032 frames, one slice per frame). The humanoid debuts at 10.9s.

## Verification

- **Geometry is byte-identical** to the pre-change baseline — FNV-1a over every mesh's position buffer, all 44 meshes / 29,878 vertices
- 150s soak: heap plateaus (13.2 MB drift, no trend); live WebGL objects stop being created after 80s and none leak; 0 context-loss events; 0 page or console errors; still responsive to hover after 150s (68ms)
- Hair sway still animates (position-buffer checksum takes 95 distinct values)
- `tsc --noEmit` clean, `npm run build` clean

Caveat: measured in headless Chromium with software rendering, so absolute numbers differ from a GPU-backed browser. Ratios and the removal of blocking are what these numbers establish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
