### PR TITLE
Landing v2: 3D-first workbench, content pages, and a mobile pass

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -438,10 +438,47 @@ function aboutDrawer(): string {
     </p>`;
 }
 
+/* --------------------------------------------------------------------- menu */
+
+/**
+ * Mobile navigation. The top bar's link row is hidden below 860px for width, which left every
+ * content page on this list unreachable by tapping — the command palette only searches exhibits.
+ * This is that row, as a list, reachable from the hamburger.
+ */
+function menuDrawer(): string {
+  const items: Array<[string, string, string]> = [
+    ['how-it-works', 'How it works', 'The pipeline, the gates, and what one photo cannot tell it'],
+    ['roadmap', 'Roadmap', 'Every release, what shipped and what deliberately did not'],
+    ['faq', 'FAQ', 'Straight answers, including the ones that are “ask a lawyer”'],
+    ['sponsor', 'Sponsors', 'Who pays for the compute, and how to help'],
+    ['attribution', 'Attribution', 'Whose designs these reconstructions belong to'],
+    ['privacy', 'Privacy', 'No analytics, no cookies — and how to verify that'],
+    ['about', 'About & contact', 'Official links, the maintainer, the licence'],
+  ];
+  return `
+    <h2>Menu</h2>
+    <nav class="mn-list" aria-label="Pages">
+      ${items
+        .map(
+          ([key, title, blurb]) => `
+        <button type="button" class="mn-item" data-drawer="${key}">
+          <span class="mn-title">${title}</span>
+          <span class="mn-blurb">${blurb}</span>
+        </button>`,
+        )
+        .join('')}
+    </nav>
+    <div class="dr-actions">
+      <a class="btn" href="${GITHUB_CORE}" target="_blank" rel="noopener noreferrer">Star on GitHub</a>
+      <a class="btn btn-accent" href="${COFFEE_URL}" target="_blank" rel="noopener noreferrer">${HEART} Sponsor</a>
+    </div>`;
+}
+
 /* --------------------------------------------------------------- public map */
 
 /** Drawer key → builder. Keys match `DRAWER_ROUTES` in router.ts, so each one is deep-linkable. */
 export const DRAWERS: Record<string, { title: string; build: () => string }> = {
+  menu: { title: 'Menu', build: menuDrawer },
   'how-it-works': { title: 'How it works', build: howItWorksDrawer },
   faq: { title: 'FAQ', build: faqDrawer },
   privacy: { title: 'Privacy', build: privacyDrawer },

--- a/src/pages/workbench.ts
+++ b/src/pages/workbench.ts
@@ -95,6 +95,11 @@ export function renderWorkbench(
           </button>
           <a class="wb-star" href="${GITHUB_CORE}" target="_blank" rel="noopener noreferrer">Star</a>
           <button type="button" class="wb-sponsor" data-drawer="sponsor">Sponsor</button>
+          <!-- Phone/tablet only: the link row above is hidden for width, and without this the
+               content pages have no tappable route in at all. -->
+          <button type="button" class="wb-menu" data-drawer="menu" aria-label="Open menu">
+            <span aria-hidden="true"></span>
+          </button>
         </div>
       </header>
 
@@ -487,9 +492,15 @@ export function renderWorkbench(
     if (syncUrl) replaceHashSilently(`#/${key}`);
   };
 
-  for (const btn of mount.querySelectorAll<HTMLButtonElement>('[data-drawer]')) {
-    on(btn, 'click', () => showDrawer(btn.dataset.drawer!));
-  }
+  /**
+   * Delegated at the root rather than bound per button: the menu drawer's own entries are
+   * `[data-drawer]` buttons that do not exist until that drawer is built, so a one-time query over
+   * the initial markup would have wired the top bar and left every menu item dead.
+   */
+  on(mount, 'click', (e: Event) => {
+    const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-drawer]');
+    if (btn?.dataset.drawer) showDrawer(btn.dataset.drawer);
+  });
   on(mount.querySelector<HTMLElement>('#wb-drawer-close')!, 'click', closeOverlays);
   on(scrim, 'click', closeOverlays);
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -15,7 +15,7 @@
  * attribution notice that cannot be pointed at is not much of a notice. They render as the
  * workbench's own drawer so there is no second layout to maintain.
  */
-export const DRAWER_ROUTES = ['how-it-works', 'faq', 'privacy', 'attribution', 'roadmap', 'sponsor', 'about'] as const;
+export const DRAWER_ROUTES = ['how-it-works', 'faq', 'privacy', 'attribution', 'roadmap', 'sponsor', 'about', 'menu'] as const;
 export type DrawerKey = (typeof DRAWER_ROUTES)[number];
 
 export type Route =

--- a/src/styles.css
+++ b/src/styles.css
@@ -219,6 +219,10 @@ body.intro-active { overflow: hidden; }
   align-items: center;
   gap: 1.5rem;
   padding: 0.85rem 1.1rem;
+  /* Notch / status bar. env() resolves to 0 on hardware without an inset, so this is free. */
+  padding-top: max(0.85rem, env(safe-area-inset-top));
+  padding-left: max(1.1rem, env(safe-area-inset-left));
+  padding-right: max(1.1rem, env(safe-area-inset-right));
   border-bottom: 1px solid var(--rule);
   background: var(--ink);
 }
@@ -825,6 +829,10 @@ body.intro-active { overflow: hidden; }
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
+  /* Home indicator: without this the last row of thumbnails is under the gesture bar. */
+  padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
+  padding-left: max(0.75rem, env(safe-area-inset-left));
+  padding-right: max(0.75rem, env(safe-area-inset-right));
   border-top: 1px solid var(--rule);
   background: var(--ink);
 }
@@ -933,6 +941,8 @@ body.intro-active { overflow: hidden; }
   overflow-y: auto;
   overscroll-behavior: contain;
   padding: 1.6rem 1.7rem 3rem;
+  padding-top: max(1.6rem, env(safe-area-inset-top));
+  padding-bottom: max(3rem, calc(2rem + env(safe-area-inset-bottom)));
   animation: dr-in var(--slow) var(--ease);
 }
 
@@ -1433,6 +1443,232 @@ body.intro-active { overflow: hidden; }
   }
   .rail-count {
     display: none;
+  }
+}
+
+
+
+/* ---- mobile menu ---- */
+
+.wb-menu {
+  display: none;
+  width: 40px;
+  align-items: center;
+  justify-content: center;
+  background: var(--ink-2);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+/* Three rules drawn with one element: the bar itself plus its two pseudo-elements. */
+.wb-menu span,
+.wb-menu span::before,
+.wb-menu span::after {
+  content: '';
+  display: block;
+  width: 16px;
+  height: 1.5px;
+  background: var(--paper);
+}
+
+.wb-menu span {
+  position: relative;
+}
+
+.wb-menu span::before { position: absolute; top: -5px; }
+.wb-menu span::after { position: absolute; top: 5px; }
+
+.mn-list {
+  display: flex;
+  flex-direction: column;
+  margin: 0 0 0.4rem;
+}
+
+.mn-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: 0;
+  border-top: 1px solid var(--rule);
+  padding: 0.85rem 0;
+  cursor: pointer;
+  font: inherit;
+}
+
+.mn-title {
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: var(--paper);
+}
+
+.mn-blurb {
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--paper-dim);
+}
+
+.mn-item:hover .mn-title {
+  color: var(--amber);
+}
+
+@media (max-width: 860px) {
+  .wb-menu {
+    display: inline-flex;
+  }
+  /* "Reference" at 0.7rem plus the label's 0.14em tracking overflowed the 74px plate and rendered
+     as "REFERENC". The plate is as wide as it should be, so the tracking gives way. */
+  .wb-ref figcaption {
+    letter-spacing: 0.04em;
+    font-size: 0.62rem;
+    text-align: center;
+  }
+}
+
+/* ---------------------------------------------- touch targets & legibility */
+
+/**
+ * Measured on a 390x844 phone before this block: 31 interactive elements were under 44px tall
+ * (the buttons sat at 33px, rail thumbnails at 36px) and the smallest rendered text was 9px.
+ * Pointer-precision is the right axis to key this on rather than width — a small laptop with a
+ * mouse does not need thumb-sized controls, and a large tablet with no mouse does.
+ */
+@media (hover: none) {
+  .btn,
+  .wb-sponsor,
+  .wb-star,
+  .wb-search,
+  .rail-arrow,
+  .wb-navlink,
+  .wb-brand,
+  .wb-drawer-close {
+    min-height: 44px;
+  }
+
+  /* The one control a reader needs on a full-screen content page, so it gets a full square. */
+  .wb-drawer-close {
+    min-width: 44px;
+  }
+
+  .wb-brand {
+    align-items: center;
+  }
+
+  .btn,
+  .wb-sponsor,
+  .wb-star,
+  .wb-search {
+    padding-top: 0.6rem;
+    padding-bottom: 0.6rem;
+  }
+
+  /* Dense data rows: 40px rather than 44px. These are list items inside their own scroller, not
+     primary actions, and 44px each would push a 150-part manifest to six screens of scrolling. */
+  .wb-part,
+  .pal-item {
+    min-height: 40px;
+  }
+
+  .faq-item summary {
+    min-height: 48px;
+    padding-right: 2.2rem;
+  }
+
+  /* The slider thumb is the hardest control to hit on a touch screen. */
+  .wb-explode input[type='range'] {
+    /* 44px of grabbable strip with a 2px visible track drawn inside it — the element box IS the
+       target area, and at 24px the thumb was the only part you could actually hit. */
+    height: 44px;
+    background: transparent;
+  }
+  .wb-explode input[type='range']::-webkit-slider-runnable-track {
+    height: 2px;
+    background: var(--rule-strong);
+  }
+  .wb-explode input[type='range']::-webkit-slider-thumb {
+    width: 22px;
+    height: 22px;
+    margin-top: -10px;
+  }
+  .wb-explode input[type='range']::-moz-range-track {
+    height: 2px;
+    background: var(--rule-strong);
+  }
+  .wb-explode input[type='range']::-moz-range-thumb {
+    width: 22px;
+    height: 22px;
+  }
+
+  /* Thumbnails have to be thumb-sized, and the number on them was the 9px text. */
+  .rail-item {
+    width: 62px;
+    height: 46px;
+  }
+  .rail-num {
+    font-size: 0.65rem;
+  }
+}
+
+/* Nothing on a phone should render below 11px. The 0.62rem labels and the 0.56rem rail number
+   were both under it. */
+@media (max-width: 860px) {
+  .label,
+  .wb-ver,
+  .wb-search kbd,
+  .rail-count,
+  .rail-num,
+  .pal-meta,
+  .wb-part-tri,
+  .wb-parts-count,
+  .rd-date,
+  .rd-status {
+    font-size: 0.7rem;
+  }
+  /* `.wb-panel > h2` carries the panel headings and is a class-plus-type selector, so it outranks
+     the `.label` class those headings also carry — bumping `.label` alone left them at 9.9px. */
+  .wb-panel > h2 {
+    font-size: 0.7rem;
+  }
+  .wb-part,
+  .card-pipeline {
+    font-size: 0.74rem;
+  }
+}
+
+/**
+ * Landscape phone. A 390px-tall viewport was giving 117px to chrome and 218px to the model, so the
+ * bars shrink and the rail loses its arrows — a horizontal swipe already scrolls it, and on a
+ * touch device that is the natural gesture anyway.
+ */
+@media (max-height: 460px) and (orientation: landscape) {
+  .wb-top {
+    padding-top: max(0.45rem, env(safe-area-inset-top));
+    padding-bottom: 0.45rem;
+  }
+  .wb-rail {
+    padding-top: 0.3rem;
+    padding-bottom: max(0.3rem, env(safe-area-inset-bottom));
+  }
+  .wb-stage {
+    grid-template-rows: 72dvh auto;
+  }
+  .wb-canvas {
+    height: 72dvh;
+  }
+  .rail-arrow {
+    display: none;
+  }
+  /* Narrower to fit the shorter viewport, but never below the 40px touch floor the block above
+     establishes — this rule runs later and would otherwise silently undo it. */
+  .rail-item {
+    width: 52px;
+    height: 40px;
+  }
+  .wb-pitch {
+    font-size: 1.3rem;
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1452,7 +1452,10 @@ body.intro-active { overflow: hidden; }
 
 .wb-menu {
   display: none;
-  width: 40px;
+  width: 44px;
+  /* Explicit height: the button's only content is a 1.5px bar plus two pseudo-elements, so with
+     height left to the content it collapsed to a 40x6px strip — measured, and unhittable. */
+  height: 40px;
   align-items: center;
   justify-content: center;
   background: var(--ink-2);
@@ -1544,7 +1547,8 @@ body.intro-active { overflow: hidden; }
   .rail-arrow,
   .wb-navlink,
   .wb-brand,
-  .wb-drawer-close {
+  .wb-drawer-close,
+  .wb-menu {
     min-height: 44px;
   }
 


### PR DESCRIPTION
Rebuilds the landing page as a 3D-first workbench, then adds the content pages the site was missing and makes the whole thing work on a phone.

## What changed

**The landing is now a workbench, not a scroll page.** One persistent full-bleed canvas with the information laid over it: reference plate, a readout (version / triangles / parts / subject / status / author), live part inspector, explode slider, animation actions, and an exhibit rail along the bottom. Switching exhibits swaps the model in place — no navigation. `⌘K` opens a command palette over the 15 exhibits.

Everything the readout shows is read back off the live scene through the existing `Viewer` API rather than restated in the page, so a number on screen cannot drift from the geometry actually running.

**Re-keyed visually.** Near-black ground, one warm amber accent, no gradients and no aurora, hairlines instead of glow, grotesk for prose and mono for measurements. `.grad` survives as a hook (both `brand()` and the demo page emit it) but is now the accent treatment rather than an animated gradient.

**A branded build loader.** The two heavy exhibits are genuinely slow — one evaluates a 2.12M-sample SDF, the other decodes a multi-megabyte encoded surface stream — and the detail route previously showed an empty scene for that whole time. The loader holds until the viewer reports a real frame, and for `prewarm` demos until that settles too, since their geometry lands after `build()` returns.

**Four content pages**, all deep-linkable: `#/how-it-works` (the eight build passes, the gates, the two finish routes, and what one photo cannot tell it — including the real recorded prompt for an exhibit, which the registry stored and nothing rendered until now), `#/faq`, `#/privacy`, `#/attribution`.

**Mobile.** Safe-area insets for notch and home indicator, a 44px touch floor keyed on pointer precision rather than width, an 11px type floor, a landscape layout that gives the model 72dvh, and a hamburger menu — without which the four new pages had no tappable route in at all.

## The capture harness is untouched

`#/demo/:id` still renders the original full viewer, deliberately. It is the surface `scripts/capture-*.mjs` loads and the globals it reads (`__IMG2THREEJS_VIEWER__` / `__IMG2THREEJS_RUNTIME__` / `__IMG2THREEJS_PARTS__`) are published there. Verified: a capture run reports ready with all three globals present, no loader and no workbench chrome in the frame. The demo-page half of `styles.css` is byte-identical to `main` (12972/12972).

## Worth a reviewer's attention

- **`public/donate.html` lost its Buy Me a Coffee badge image.** That `<img>` came from `cdn.buymeacoffee.com` and was the one third-party request on the site — it handed a visitor's IP to a CDN before they clicked anything. The privacy page's claim is false if that line comes back.
- **`src/pages/home.ts` and `src/hero-stage.ts` are deleted.** Only `home.ts` used `hero-stage`, and the workbench replaces both. Recoverable: `git show main:src/hero-stage.ts`.
- **The animated gradient on "img2threejs" is gone**, which reverses an earlier explicit request. This design brief called for no gradients; say so if it should come back for the brand specifically.
- **Honest limitation, documented in `src/loader.ts`:** `build()` is synchronous by contract, so CSS animation cannot advance while it runs. Every loader stage is drawn so a frozen frame still reads as the logo, and the phase line carries the state. Fixing it properly means chunking `build()` or moving it to a worker.

## Verification

- `tsc --noEmit`, `vite build`, and `check-showcase-safety.mjs` all pass; 0 console errors
- No horizontal overflow at 360 / 375 / 390 / 430 / 768 / 844×390 / 1024 / 1280 / 1440
- 0 controls under 40px on iPhone SE / 14 / 14 Pro Max / Android 360 / landscape / iPad, menu open and closed; smallest rendered type 11.2px
- Exhibit swap via rail, palette and deep link leaves exactly one canvas — no viewer leak
- All 7 content pages reachable by tap on a phone, each opening the right page and URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
