### PR TITLE
chore(showcase): serve from the img2threejs.io apex domain

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+img2threejs.io

--- a/src/site-data.ts
+++ b/src/site-data.ts
@@ -18,7 +18,7 @@ export const BASE = import.meta.env.BASE_URL;
  */
 export const GITHUB_CORE = 'https://github.com/img2threejs/img2threejs';
 export const GITHUB_SHOWCASE = 'https://github.com/img2threejs/img2threejs-showcase';
-export const SITE_URL = 'https://img2threejs.github.io/img2threejs-showcase/';
+export const SITE_URL = 'https://img2threejs.io/';
 export const CHANGELOG_URL = `${GITHUB_CORE}/blob/main/CHANGELOG.md`;
 export const ROADMAP_URL = `${GITHUB_CORE}/blob/main/ROADMAP.md`;
 export const LICENSE_URL = `${GITHUB_CORE}/blob/main/LICENSE`;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from 'vite';
 
+/**
+ * Served from the apex domain `img2threejs.io` (see `public/CNAME`), so assets resolve from the
+ * root. This was `/img2threejs-showcase/` while the site lived on the github.io project path.
+ */
 export default defineConfig({
-  base: '/img2threejs-showcase/',
+  base: '/',
 });


### PR DESCRIPTION
Switches the showcase from `img2threejs.github.io/img2threejs-showcase/` to the newly registered apex domain `img2threejs.io`.

## Changes
- `public/CNAME` — `img2threejs.io`. With the Actions deploy flow the custom domain is read from the artifact root, so this is what actually binds the domain, rather than a manual Pages setting that a later deploy could clear.
- `vite.config.ts` — `base: '/img2threejs-showcase/'` to `'/'`, since the apex domain serves from root.
- `src/site-data.ts` — `SITE_URL` now points at the new domain; it feeds the "This site" row in the authenticity section.

No other change was needed: every asset reference in `src/` already goes through `import.meta.env.BASE_URL`, and there are no canonical / `og:url` / sitemap tags carrying the old URL.

## DNS (already live and verified)
- `img2threejs.io` A to the four `185.199.10{8,9,10,11}.153` Pages edges, AAAA to the four `2606:50c0:800{0..3}::153`
- `www` CNAME to `img2threejs.github.io.`
- Domain verified at the org level via the `_github-pages-challenge-img2threejs` TXT record, so it cannot be claimed by another account.

## Verification
`npm ci && npm run build` passes; `dist/CNAME` is emitted and `dist/index.html` references `/assets/...` at the root. The old `github.io` path 301s to the custom domain once this lands, so existing links keep working.

After merge: enable **Enforce HTTPS** in Pages settings once the Let's Encrypt cert finishes provisioning. There is no CAA record on the zone, so nothing blocks issuance.