### PR TITLE
docs(showcase): point every site link at img2threejs.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to contribute a showcase demo
 
 This turns a model you generated with [img2threejs](https://github.com/hoainho/img2threejs)
-into a live entry on the [gallery](https://hoainho.github.io/img2threejs-showcase/).
+into a live entry on the [gallery](https://img2threejs.io/).
 Every step below has a copy-paste command — you shouldn't need to write anything
 from scratch except the factory code itself and the demo's description.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ TypeScript factory function, running live in your browser.
   <img src=".github/readme-assets/hero-gallery.png" alt="img2threejs-showcase live gallery" width="100%">
 </p>
 
-**Live gallery →** https://hoainho.github.io/img2threejs-showcase/
+**Live gallery →** https://img2threejs.io/
 Click any card for the full-viewport viewer (`#/demo/:id`): drag to orbit,
 scroll to zoom, and read the reference photo it was rebuilt from.
 
@@ -25,7 +25,7 @@ scroll to zoom, and read the reference photo it was rebuilt from.
 <td width="240"><img src=".github/readme-assets/sony-wf1000xm3.png" width="220"></td>
 <td>
 
-**[Sony WF-1000XM3 Earbuds + Case](https://hoainho.github.io/img2threejs-showcase/#/demo/sony-wf1000xm3)**
+**[Sony WF-1000XM3 Earbuds + Case](https://img2threejs.io/#/demo/sony-wf1000xm3)**
 Matte-black true-wireless earbuds + case with rose-gold trim; the lid opens
 and both buds spin in a looping animation.
 `object` · `final` · by [Hoài Nhớ](https://github.com/hoainho)
@@ -36,7 +36,7 @@ and both buds spin in a looping animation.
 <td width="240"><img src=".github/readme-assets/issaca-shotgun.png" width="220"></td>
 <td>
 
-**[ISSACA 12 Gauge Shotgun](https://hoainho.github.io/img2threejs-showcase/#/demo/issaca-shotgun)**
+**[ISSACA 12 Gauge Shotgun](https://img2threejs.io/#/demo/issaca-shotgun)**
 Stylized bullpup shotgun with a working muzzle flash, full recoil kick, and
 an ejecting shell.
 `object` · `final` · by [Hoài Nhớ](https://github.com/hoainho)
@@ -47,7 +47,7 @@ an ejecting shell.
 <td width="240"><img src=".github/readme-assets/gerber-knife.png" width="220"></td>
 <td>
 
-**[Gerber Paracord Knife](https://hoainho.github.io/img2threejs-showcase/#/demo/gerber-knife)**
+**[Gerber Paracord Knife](https://img2threejs.io/#/demo/gerber-knife)**
 Skeletonized tactical knife wrapped in orange paracord, slowly rocking on a
 studio turntable to catch the stonewash finish.
 `object` · `final` · by [Hoài Nhớ](https://github.com/hoainho)
@@ -58,7 +58,7 @@ studio turntable to catch the stonewash finish.
 <td width="240"><img src=".github/readme-assets/doraemon-house.png" width="220"></td>
 <td>
 
-**[Doraemon House (isometric diorama)](https://hoainho.github.io/img2threejs-showcase/#/demo/doraemon-house)**
+**[Doraemon House (isometric diorama)](https://img2threejs.io/#/demo/doraemon-house)**
 Isometric residential diorama with swaying trees, twinkling dusk windows,
 and both characters resting on the roof.
 `object` · `final` · by [Hoài Nhớ](https://github.com/hoainho)
@@ -69,7 +69,7 @@ and both characters resting on the roof.
 <td width="240"><img src=".github/readme-assets/warhauler.png" width="220"></td>
 <td>
 
-**[War-Hauler "SECTOR 07"](https://hoainho.github.io/img2threejs-showcase/#/demo/warhauler)**
+**[War-Hauler "SECTOR 07"](https://img2threejs.io/#/demo/warhauler)**
 Armored 6-wheeled hauler with glowing reactor hubs, exhaust smoke, and
 rolling wheels.
 `object` · `final` · by [Hoài Nhớ](https://github.com/hoainho)
@@ -80,7 +80,7 @@ rolling wheels.
 <td width="240"><img src=".github/readme-assets/crown-chest.png" width="220"></td>
 <td>
 
-**[Crowned Loot Chest](https://hoainho.github.io/img2threejs-showcase/#/demo/crown-chest)**
+**[Crowned Loot Chest](https://img2threejs.io/#/demo/crown-chest)**
 Rounded loot chest with a purple-to-teal enamel gradient and an emissive
 crown emblem. *(placeholder mesh — not yet a final img2threejs reconstruction)*
 `object` · `placeholder` · by [Hoài Nhớ](https://github.com/hoainho)
@@ -192,7 +192,7 @@ supporting continued development:
 
 <a href="https://www.buymeacoffee.com/hoainhowors" target="_blank" rel="noopener noreferrer"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
-VietQR / MoMo / PayPal also work — see the [donate page](https://hoainho.github.io/img2threejs-showcase/donate.html).
+VietQR / MoMo / PayPal also work — see the [donate page](https://img2threejs.io/donate.html).
 
 ## Star History
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       name="description"
       content="Every object and character here was rebuilt in code from a single reference image, then rendered live in your browser — animation-ready Three.js, no imported meshes."
     />
-    <meta name="theme-color" content="#0a0d12" />
+    <meta name="theme-color" content="#0b0b0d" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href="https://img2threejs.io/" />
 

--- a/src/site-data.ts
+++ b/src/site-data.ts
@@ -7,14 +7,19 @@
 export const BASE = import.meta.env.BASE_URL;
 
 /**
- * Canonical identity is the `img2threejs` org, confirmed by the maintainer: it is what the core
- * tool's own README and its git origin use. `hoainho/…` (this showcase's README, and `registry.ts`
- * before it was aligned) is the personal fork, and `img2threejs-showcase.pages.dev` — cited in the
- * core ROADMAP — is a secondary deploy. The authenticity section states these verbatim, so they
- * must not drift: `registry.ts`'s `REPO` is aligned to the same org.
+ * Canonical identity is the `img2threejs` org: it is what the core tool's own README and its git
+ * origin use, and `registry.ts`'s `REPO` is aligned to it. The authenticity section renders these
+ * verbatim, so they must not drift.
  *
- * Still stale and worth a follow-up commit outside this redesign: this repo's own README.md links
- * `hoainho.github.io/img2threejs-showcase/` in 8 places.
+ * `SITE_URL` is the apex custom domain, which is now the only address the project publishes. The
+ * three URLs that used to appear in its place are all retired: `img2threejs.github.io/
+ * img2threejs-showcase/` (the org's Pages project path, which GitHub now 301s here),
+ * `hoainho.github.io/…` (a personal fork's Pages, never canonical) and
+ * `img2threejs-showcase.pages.dev` (a secondary Cloudflare deploy). Reintroducing any of them
+ * would split the site's identity across hosts again.
+ *
+ * `index.html` hardcodes this same origin in `og:image`, `og:url` and `link[rel=canonical]`,
+ * because a static document cannot import from here — change both together.
  */
 export const GITHUB_CORE = 'https://github.com/img2threejs/img2threejs';
 export const GITHUB_SHOWCASE = 'https://github.com/img2threejs/img2threejs-showcase';


### PR DESCRIPTION
Follow-up to #36 and #37. The domain switch made the site's own address canonical, but this repo's prose was still sending readers to two retired hosts.

## Changes
- **README.md** (8 links) and **CONTRIBUTING.md** (1) pointed at `hoainho.github.io/img2threejs-showcase/` — a *personal fork's* Pages, which was never the canonical address even before the domain. All now `img2threejs.io`.
- **src/site-data.ts** — the header comment documented the pre-domain world and carried a "still stale, fix later" note about exactly the README links this PR fixes. Rewritten to name the three retired URLs (`img2threejs.github.io/img2threejs-showcase/`, `hoainho.github.io/…`, `img2threejs-showcase.pages.dev`) so none of them gets reintroduced, and to record that `index.html` hardcodes the same origin and has to change with it.
- **index.html** — `theme-color` was `#0a0d12`, a leftover from the v1 blue-black. The v2 `--ink` is `#0b0b0d`; the mobile browser chrome now matches the page it frames.

## Notes
Every rewritten link was checked against `src/router.ts` rather than assumed: `#/demo/:id` is the route the router comments call out as deliberately UNCHANGED for README links, and the bare `/` and `/donate.html` targets both resolve. The 15 `github.com/img2threejs/img2threejs-showcase/blob/main/…` source links are untouched — those are repo URLs, not site URLs.

`npm ci && npm run build` passes.