### PR TITLE
chore(showcase): bump the header version badge to v1.5.1

### DIFF
--- a/src/site-data.ts
+++ b/src/site-data.ts
@@ -33,7 +33,7 @@ export const DONATE_URL = `${BASE}donate.html`;
 
 export const CONTACT_EMAIL = 'hoainho.work@gmail.com';
 export const CONTACT_NAME = 'Nick';
-export const CURRENT_VERSION = 'v1.5.0';
+export const CURRENT_VERSION = 'v1.5.1';
 
 /**
  * Wraps every occurrence of the product name in the animated gradient span, so the brand reads the


### PR DESCRIPTION
The version badge beside the brand in the workbench header still read `v1.5.0`. The site ships 1.5.1 — `SKILL.md`, the README badge and every `generatedWith` string in the demo registry already say so.

## Change

One constant, rendered in `<header class="wb-top">` as `<span class="wb-ver mono">`:

```diff
-export const CURRENT_VERSION = 'v1.5.0';
+export const CURRENT_VERSION = 'v1.5.1';
```

`src/pages/workbench.ts` is its only consumer, so the header is the only place the string surfaces.

## Verification

`npm ci` and `npm run build` both exit 0 on this branch.