### PR TITLE
feat(analytics): add GA4 with sponsor impression and click reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,12 @@ issue form first to get early feedback on scope before doing the work.
 - three ^0.169.0, TypeScript ^5.6.0, Vite ^5.4.0
 - Hash router only (`#/`, `#/demo/:id`) so GitHub Pages project-site refreshes
   never 404
-- No runtime network calls or external CDN/fonts — everything is bundled
+- No network call anywhere in the rendering path, and no external CDN or remote fonts — everything
+  an exhibit needs is bundled. The site's one third-party request is its Google Analytics script; it
+  renders nothing, and demo code is still barred from `fetch`/`XMLHttpRequest`/`WebSocket` by the
+  safety check. Every event the site sends is a named function in `src/analytics.ts`; setup, the
+  event reference and the sponsor report live in [`docs/ANALYTICS.md`](docs/ANALYTICS.md), and the
+  in-site privacy page states the same thing to visitors
 
 ## Develop
 

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -1,0 +1,267 @@
+# Analytics
+
+Google Analytics 4, installed for one primary reason: **logo sponsors are owed evidence that their
+placement does something.** The whole sponsor report is two numbers per sponsor per month — how many
+times the card was seen, how many times it was clicked — and everything else measured here exists to
+answer "where do people actually spend their time on this site".
+
+Every event the site can send is a named function in **[`src/analytics.ts`](../src/analytics.ts)**.
+No page calls `gtag()` directly. If an event is not in that file, the site does not send it.
+
+---
+
+## 1. Setup, step by step
+
+Nine steps. Steps 3, 4 and 5 are **not optional** — the site's own privacy page makes claims that
+are only true if you do them, and step 5 prevents double-counted page views.
+
+### Step 1 — Create the property and the data stream
+
+1. <https://analytics.google.com> → **Admin** (bottom left) → **Create** → **Property**.
+2. Property name `img2threejs`, reporting time zone **(GMT+07:00) Vietnam**, currency as you prefer.
+3. Business details → whatever fits; objectives → **Examine user behavior**.
+4. Platform → **Web**. Website URL `https://img2threejs.io`, stream name `img2threejs.io`.
+5. On the stream page, copy the **Measurement ID** — it looks like `G-ABC1234XYZ`.
+
+### Step 2 — Paste the Measurement ID in the two places that need it
+
+It is not a secret; every visitor receives it in the page. It lives in the repo in the clear, in
+**two** files, because `public/donate.html` is copied verbatim by Vite and cannot import from `src/`
+(the same reason `index.html` duplicates `SITE_URL` in its Open Graph tags):
+
+| File | What to change |
+| --- | --- |
+| `src/site-data.ts` | `export const GA_MEASUREMENT_ID: string = GA_MEASUREMENT_ID_PLACEHOLDER;` → `= 'G-ABC1234XYZ';` |
+| `public/donate.html` | `var GA_MEASUREMENT_ID = 'G-XXXXXXXXXX';` → your ID |
+
+Until both are changed, **nothing is sent at all** — no script is loaded, no `dataLayer` is created.
+That is deliberate: an analytics install that silently half-works is worse than one that is off.
+
+### Step 3 — Turn the advertising features off
+
+The privacy page states that none of these are on. Make that true.
+
+* **Admin → Data collection and modification → Data collection** → **Google signals**: off.
+* Same screen → **Advertising personalization**: off (or exclude all regions).
+* **Admin → Account settings → Data sharing settings**: uncheck the Google-products/advertising
+  sharing options; leave technical support if you want it.
+
+### Step 4 — Set data retention to 14 months
+
+**Admin → Data collection and modification → Data retention** → **Event data retention: 14 months**
+→ Save. The privacy page says 14 months by name, and the default for a new property is shorter than
+that. 14 is also the shortest setting that still allows a year-on-year comparison in a sponsor report.
+
+### Step 5 — Fix Enhanced measurement (this one matters)
+
+**Admin → Data streams → your stream → Enhanced measurement → the gear icon.**
+
+* **Page views → "Page changes based on browser history events": TURN THIS OFF.**
+  The site is a hash router, and it rewrites the URL with `history.replaceState` every time you
+  change exhibit or open a content page. Left on, GA4 would send its own page view for each of those
+  *in addition* to the one the site sends, and every page-view number in the property would be
+  roughly double. The site sends its own with `send_page_view: false` precisely so it can control this.
+* **Site search: off.** The command palette already reports GA4's own `search` event with the real
+  `search_term`; the automatic version looks for query parameters this site does not use.
+* **Scrolls / Outbound clicks / File downloads: leave as they are.** They cost nothing and use
+  different event names than ours, so they cannot double-count `outbound_click`.
+
+### Step 6 — Register the custom dimensions
+
+GA4 will collect the parameters immediately but will not *report* on them until they are registered,
+and **registration is not retroactive** — so do this before you announce the site, not after.
+
+**Admin → Data display → Custom definitions → Create custom dimension**, scope **Event** for every
+one. Name it whatever reads well; the **Event parameter** must match exactly.
+
+Do these five first — they are the sponsor report:
+
+| Dimension name | Event parameter |
+| --- | --- |
+| Sponsor ID | `sponsor_id` |
+| Sponsor name | `sponsor_name` |
+| Placement | `placement` |
+| Link CTA | `link_cta` |
+| Support channel | `channel` |
+
+Then these, for "where are people interacting":
+
+| Dimension name | Event parameter |
+| --- | --- |
+| Exhibit ID | `exhibit_id` |
+| Exhibit title | `exhibit_title` |
+| Entry point | `entry` |
+| Surface | `surface` |
+| Drawer | `drawer` |
+| Open source | `source` |
+| Part name | `part_name` |
+| Animation label | `action_label` |
+| Quality level | `quality_level` |
+| First input | `input` |
+| FAQ question | `question` |
+| Site version | `site_version` |
+
+Optional, if you want them in reports: `subject_class`, `exhibit_status`, `generated_with`,
+`action_id`, `part_kind`, `link_url`, `link_domain`, `link_label`, `prewarm`, `isolated`.
+
+And as **custom metrics** (same screen, *Custom metrics* tab, scope Event, unit *Standard*
+except where noted):
+
+| Metric name | Event parameter | Unit |
+| --- | --- | --- |
+| Load time | `load_ms` | Milliseconds |
+| Triangles | `triangles` | Standard |
+| Part count | `part_count` | Standard |
+| Explode value | `explode_value` | Standard |
+| Search results | `result_count` | Standard |
+
+### Step 7 — Mark the key events
+
+**Admin → Data display → Key events → New key event** (older UI: *Conversions*):
+
+* `sponsor_click` — the one that pays for the compute.
+* `support_click` — donations.
+* `source_click` — someone went to read generated code, which is the product's actual pitch.
+
+Key events show up in the standard reports without an Exploration, which is what makes a monthly
+sponsor number a thirty-second job instead of a report build.
+
+### Step 8 — Verify before you trust it
+
+Two independent checks, and do both:
+
+1. **On the deployed site**: open `https://img2threejs.io/?analytics_debug=1#/` and watch the
+   browser console. Every event prints with its parameters as it is sent, and if analytics is off
+   the console says which of the five reasons it is off for. Then open **Admin → DebugView** in GA4
+   and confirm the same events arrive there within a few seconds.
+2. **Locally**: `npm run dev`, then `http://localhost:5173/?analytics_debug=1#/` (whatever port Vite
+   prints). `analytics_debug=1`
+   is what overrides the production-host allowlist, so this is the only way local events are sent —
+   point it at a throwaway property, or just read the console and let the sends fail.
+
+`?analytics_debug=1` is also the honest answer to a visitor who asks whether the privacy page is
+accurate: it prints exactly what leaves the browser.
+
+### Step 9 — Deploy
+
+Nothing to configure. `.github/workflows/deploy.yml` builds and publishes on push to `main`; the
+Measurement ID is in the source, so there is no secret to add and no workflow change to make.
+
+---
+
+## 2. Every event this site sends
+
+`site_version` rides on all of them.
+
+### Sponsors — the reason this exists
+
+| Event | When | Parameters |
+| --- | --- | --- |
+| `sponsor_impression` | ≥25% of a sponsor's card is on screen, once per sponsor per opening of the sponsor page | `sponsor_id`, `sponsor_name`, `placement` |
+| `sponsor_click` | A sponsor link is clicked **anywhere on the site** | `sponsor_id`, `sponsor_name`, `placement`, `link_url`, `link_cta`, `exhibit_id` |
+| `support_click` | A donation or community channel is clicked | `channel`, `placement` |
+
+`placement` for a sponsor is one of `sponsor_drawer`, `demo_provenance` (an exhibit's own
+"Generated by Tripo" provenance link), `menu_drawer`, `donate_page`.
+`channel` is one of `buymeacoffee`, `donate_page`, `paypal`, `discord`, `github_sponsors`, `email`.
+`momo_vietqr` exists in the vocabulary but is never emitted: the MoMo/VietQR code is an image, and
+the scan happens on a phone the page never hears from. Inventing an event for it would put a number
+in the report that means nothing, so the donate page measures the two real links and stops there.
+
+Attribution is by **hostname**, resolved against `SPONSORS` in `src/site-data.ts`. That is what makes
+an exhibit's Tripo provenance link count for Tripo without `pages/demo.ts` knowing what a sponsor is —
+add another sponsor link anywhere tomorrow and it is attributed with no code change.
+
+### Exhibits
+
+| Event | When | Parameters |
+| --- | --- | --- |
+| `exhibit_view` | An exhibit is selected or deep-linked | `exhibit_id`, `exhibit_title`, `subject_class`, `exhibit_status`, `generated_with`, `entry`, `surface` |
+| `exhibit_ready` | The viewer painted a real frame — after prewarm, build, texture decode and shader compile | `exhibit_id`, `exhibit_title`, `load_ms`, `triangles`, `part_count`, `prewarm`, `surface` |
+| `exhibit_prewarm_failed` | A heavy exhibit's precompute rejected and it fell back | `exhibit_id`, `surface` |
+| `viewer_interact` | First orbit / zoom / touch, **once per exhibit load** | `exhibit_id`, `input`, `surface` |
+| `animation_play` / `animation_stop` | An animation button | `exhibit_id`, `action_id`, `action_label`, `surface` |
+| `explode_use` | Explode slider settled (700 ms debounce) or the viewer's toggle | `exhibit_id`, `explode_value`, `surface` |
+| `part_select` / `part_isolate` | A named part is inspected | `exhibit_id`, `part_name`, `part_kind`, `triangles`, `surface` |
+| `quality_switch` | A detail-level button, sent before the reload it triggers | `exhibit_id`, `quality_level` |
+
+`entry` says how they got there: `default`, `rail`, `arrow`, `keyboard`, `palette`, `deeplink`,
+`hashchange`. `surface` is `workbench` (the landing workbench) or `viewer` (`#/demo/:id`).
+
+**The number worth watching**: `exhibit_view` minus `exhibit_ready`, per exhibit. A visitor who
+leaves during a multi-second precompute never becomes an `exhibit_ready`, so that gap is the
+abandonment rate for the slow exhibits — which no session-duration average will tell you.
+
+### Navigation and reading
+
+| Event | When | Parameters |
+| --- | --- | --- |
+| `page_view` | Every route, sent manually | `page_location`, `page_title`, `page_referrer` |
+| `drawer_open` | A content page opens | `drawer`, `source` |
+| `search` | Command palette query, settled (900 ms debounce) | `search_term`, `result_count` |
+| `palette_open` | ⌘K or the Exhibits button | `source` |
+| `faq_open` | A FAQ answer is expanded | `question_index`, `question` |
+| `source_click` | "Read the source" / "View generated source" | `exhibit_id`, `surface` |
+| `open_full_viewer` | Workbench → `#/demo/:id` | `exhibit_id` |
+| `outbound_click` | Any other external link | `link_url`, `link_domain`, `link_label`, `placement`, `exhibit_id` |
+
+`drawer_open`'s `source` distinguishes `header_nav`, `header_cta` (the Sponsor button in the top
+bar), `menu_button`, `menu_drawer` and `deeplink` — which is how the header CTA earns its place.
+
+**On `page_location`**: the route is promoted out of the fragment before it is reported, so
+`https://img2threejs.io/#/x/warrior` is sent as `https://img2threejs.io/x/warrior`. The address bar
+is untouched. Without this, GA4 strips the fragment and every route on the site reports as `/`.
+
+---
+
+## 3. The monthly sponsor report
+
+**Explore → Blank**, then:
+
+* **Dimensions**: add `Sponsor name`, `Placement`, `Event name`.
+* **Metrics**: add `Event count`.
+* **Rows**: `Sponsor name`. **Columns**: `Event name`. **Values**: `Event count`.
+* **Filter**: `Event name` *matches regex* `sponsor_impression|sponsor_click`.
+* Set the date range to the month.
+
+That gives one row per sponsor with an impressions column and a clicks column; CTR is clicks ÷
+impressions. Add `Placement` as a second row dimension to split a sponsor's own card from its
+provenance links on the exhibits.
+
+**Say what the numbers mean when you send them.** Impressions are "at least a quarter of the card
+scrolled into view, counted once per visit to the sponsor page" — a deliberately conservative
+denominator that does not count cards nobody scrolled to. Clicks are outbound clicks, not verified
+arrivals; a sponsor's own analytics will read slightly lower, and it is better for them to hear that
+from you first. Ad blockers suppress both sides of the ratio, so the CTR is sound even though the
+absolute numbers are floors, not totals.
+
+---
+
+## 4. Changing things
+
+**A new sponsor**: add an entry to `SPONSORS` in `src/site-data.ts` with a stable `id`. Impressions,
+clicks and hostname attribution all start working with no other change. **Never rename an `id`** once
+a report has gone out — it splits that sponsor's history into two rows.
+
+**A new event**: add a named function to `src/analytics.ts` and call it from the page. Nothing else
+should ever call `gtag()`. Then register any new parameters as custom dimensions (step 6) —
+otherwise they are collected but not reportable.
+
+**A change to what is collected**: update the privacy drawer in `src/content.ts` in the same commit.
+It is written to match `src/analytics.ts` line for line, it names the cookies, and it tells visitors
+to verify it with `?analytics_debug=1`. A privacy page that has drifted from the code is worse than
+no privacy page, because it is a claim rather than an omission.
+
+## 5. When nothing is sent
+
+`src/analytics.ts` refuses to measure, in this order, and `?analytics_debug=1` prints which:
+
+1. The Measurement ID is still the placeholder.
+2. The visitor opted out — `img2threejs:analytics-opt-out` in `localStorage`, set by the switch on
+   the privacy page or by `?analytics=off`. It also sets GA's own `ga-disable-<ID>` kill switch, so
+   it takes effect without a reload.
+3. A headless capture run (`?capture=1`, `mask`, `back`, `bg`, `reviewWhite`) — `scripts/capture-*.mjs`
+   loads exhibit pages dozens of times per review and none of it is traffic.
+4. An automated browser (`navigator.webdriver`) — the same reason, for runners that pass no flag.
+5. The hostname is not in `ANALYTICS_HOSTS`, so `localhost`, `vite preview`, a fork's Pages build and
+   any preview deploy cannot pollute the property the sponsor report is drawn from.

--- a/public/donate.html
+++ b/public/donate.html
@@ -265,7 +265,7 @@
     -->
     <script>
       (function () {
-        var GA_MEASUREMENT_ID = 'G-XXXXXXXXXX';
+        var GA_MEASUREMENT_ID = 'G-7GXMDHK2DE';
         var HOSTS = ['img2threejs.io', 'www.img2threejs.io'];
         var debug = /[?&]analytics_debug=1\b/.test(location.search);
 

--- a/public/donate.html
+++ b/public/donate.html
@@ -249,5 +249,65 @@
         <span class="heart">&lt;3</span> &nbsp;·&nbsp; <a href="./">&larr; back to the img2threejs demo gallery</a>
       </footer>
     </main>
+
+    <!--
+      Analytics, standalone.
+
+      This page lives in `public/`, which Vite copies verbatim, so it cannot import from
+      `src/site-data.ts` the way the app does. The measurement ID below is therefore a SECOND copy
+      of `GA_MEASUREMENT_ID` — change both together. (`index.html` already duplicates `SITE_URL` in
+      its Open Graph tags for the same reason, and for the same reason it says so out loud.)
+
+      The three gates that stop the app from reporting junk are repeated here rather than assumed:
+      a non-production host, an automated browser, and the visitor's own opt-out — the same
+      `img2threejs:analytics-opt-out` key the privacy page writes, so opting out on the gallery
+      opts out here too.
+    -->
+    <script>
+      (function () {
+        var GA_MEASUREMENT_ID = 'G-XXXXXXXXXX';
+        var HOSTS = ['img2threejs.io', 'www.img2threejs.io'];
+        var debug = /[?&]analytics_debug=1\b/.test(location.search);
+
+        var optedOut = false;
+        try {
+          optedOut = localStorage.getItem('img2threejs:analytics-opt-out') === '1';
+        } catch (e) { /* storage blocked is not an opt-out */ }
+
+        if (GA_MEASUREMENT_ID === 'G-XXXXXXXXXX') return;
+        if (optedOut || navigator.webdriver) return;
+        if (!debug && HOSTS.indexOf(location.hostname) === -1) return;
+
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = function () { window.dataLayer.push(arguments); };
+        gtag('js', new Date());
+        // This page has a real path, so GA4's own automatic page view is correct here — unlike the
+        // gallery, which is one document behind a hash router and has to send its own.
+        gtag('config', GA_MEASUREMENT_ID, { debug_mode: debug });
+
+        var script = document.createElement('script');
+        script.async = true;
+        script.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_MEASUREMENT_ID;
+        document.head.appendChild(script);
+
+        /**
+         * `support_click`, with the same `channel` vocabulary `src/analytics.ts` uses, so the
+         * donation funnel reads as one report across both pages instead of two that have to be
+         * added up by hand. The QR code is deliberately not measured: it is an image, and a scan
+         * happens on a phone this page never hears from — inventing an event for it would put a
+         * number in the report that means nothing.
+         */
+        document.addEventListener('click', function (event) {
+          var anchor = event.target.closest && event.target.closest('a[href]');
+          if (!anchor) return;
+          var href = anchor.getAttribute('href') || '';
+          var channel = null;
+          if (href.indexOf('paypal.') !== -1) channel = 'paypal';
+          else if (href.indexOf('buymeacoffee.com') !== -1) channel = 'buymeacoffee';
+          if (!channel) return;
+          gtag('event', 'support_click', { channel: channel, placement: 'donate_page' });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,0 +1,639 @@
+/**
+ * Analytics — Google Analytics 4, in one file.
+ *
+ * Every event this site can send is a named function below. Pages call `trackSponsorClick(...)`;
+ * no page ever calls `gtag('event', ...)` itself. That is the whole point of the file: the event
+ * taxonomy and its parameter names are readable in one place, so a report built in the GA4 UI
+ * cannot be quietly orphaned by a page renaming its event, and a new page cannot invent a
+ * seventeenth spelling of "the visitor clicked a sponsor".
+ *
+ * SPONSOR REPORTING IS THE PRIMARY JOB. Sponsors are sent an impression count, a click count and
+ * the click-through rate between them, so both halves of that ratio have to be measured on the
+ * same terms:
+ *   - `sponsor_impression` fires when a sponsor's card is actually on screen (IntersectionObserver,
+ *     not merely "the drawer was opened"), once per sponsor per drawer opening.
+ *   - `sponsor_click` fires on the outbound click, carrying the same `sponsor_id`.
+ * `sponsor_id` is a stable slug, never the display name: a sponsor that rebrands must not split
+ * into two rows in a report that spans the rename.
+ *
+ * WHAT IS DELIBERATELY NOT COLLECTED: nothing typed by the visitor except exhibit-search terms
+ * (which are matched against a fixed list of exhibit titles), no form input, no identifiers of our
+ * own making, and no attempt to join a visit to a person. See the privacy drawer in `content.ts` —
+ * it is written to match this file, and changing what is collected here means changing it there.
+ */
+
+import { isCaptureRun } from './capture-run';
+import {
+  ANALYTICS_HOSTS,
+  CURRENT_VERSION,
+  GA_MEASUREMENT_ID,
+  GA_MEASUREMENT_ID_PLACEHOLDER,
+  SPONSORS,
+  type SponsorEntry,
+} from './site-data';
+
+/* --------------------------------------------------------------------------- types */
+
+/** GA4 accepts strings, numbers and booleans as parameter values. `undefined` keys are dropped. */
+export type EventParams = Record<string, string | number | boolean | undefined>;
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+/** Which UI a measurement came from. The same action exists in both, and they measure differently. */
+export type Surface = 'workbench' | 'viewer';
+
+/** Where a sponsor was shown or clicked. One value per physical place a sponsor link exists. */
+export type SponsorPlacement =
+  | 'sponsor_drawer'
+  | 'demo_provenance'
+  | 'menu_drawer'
+  | 'donate_page';
+
+/* ----------------------------------------------------------------------- GA4 limits */
+
+/**
+ * GA4 truncates silently rather than rejecting, which is how a report ends up full of values that
+ * are almost right. Clipping here, where the limits are written down, at least makes the loss
+ * visible in one place. Limits per Google's "GA4 event" reference: parameter name 40 characters,
+ * parameter value 100 characters, 25 parameters per event.
+ */
+const MAX_PARAM_VALUE_CHARS = 100;
+const MAX_PARAMS_PER_EVENT = 25;
+
+function clip(value: string): string {
+  return value.length <= MAX_PARAM_VALUE_CHARS ? value : value.slice(0, MAX_PARAM_VALUE_CHARS);
+}
+
+/* ------------------------------------------------------------------- enable / disable */
+
+const OPT_OUT_KEY = 'img2threejs:analytics-opt-out';
+
+/** `?analytics=off` opts out for good; `?analytics=on` undoes it. Both work on the hash too. */
+function urlFlag(name: string): string | null {
+  const fromSearch = new URLSearchParams(window.location.search).get(name);
+  if (fromSearch !== null) return fromSearch;
+  const hashQuery = window.location.hash.split('?')[1];
+  return hashQuery ? new URLSearchParams(hashQuery).get(name) : null;
+}
+
+function readOptOut(): boolean {
+  try {
+    return window.localStorage.getItem(OPT_OUT_KEY) === '1';
+  } catch {
+    // Storage blocked entirely (private mode, hardened settings). Not an opt-out on its own.
+    return false;
+  }
+}
+
+/**
+ * Persists the visitor's choice and takes effect immediately: GA's own kill switch
+ * (`window['ga-disable-<ID>']`) is documented to stop all sending for that measurement ID without a
+ * reload, so an opt-out does not have to wait for the next page load to mean something.
+ */
+export function setAnalyticsOptOut(optedOut: boolean): void {
+  try {
+    if (optedOut) window.localStorage.setItem(OPT_OUT_KEY, '1');
+    else window.localStorage.removeItem(OPT_OUT_KEY);
+  } catch {
+    /* nothing we can do; the window flag below still applies for this page's lifetime */
+  }
+  (window as unknown as Record<string, unknown>)[`ga-disable-${GA_MEASUREMENT_ID}`] = optedOut;
+  enabled = !optedOut && disabledReason() === null;
+  /**
+   * Opting back in has to actually resume, in this page's lifetime.
+   *
+   * A visitor who opted out on an earlier visit gets no gtag.js at all — `initAnalytics` returned
+   * before loading it — so flipping `enabled` back on would leave the privacy page saying
+   * "analytics is on" while `track()` silently dropped everything for want of a `gtag`. Loading it
+   * here is what makes the switch mean the same thing in both directions.
+   */
+  if (enabled && !window.gtag) loadGtag();
+}
+
+export function isOptedOut(): boolean {
+  return readOptOut();
+}
+
+/**
+ * Why analytics is off, or `null` when it is on. Returned as a string rather than a boolean so
+ * `?analytics_debug=1` can print the actual reason — "it silently does nothing" is the single most
+ * expensive failure mode in an analytics install.
+ */
+function disabledReason(): string | null {
+  if (GA_MEASUREMENT_ID === GA_MEASUREMENT_ID_PLACEHOLDER || !GA_MEASUREMENT_ID) {
+    return 'no measurement ID configured in src/site-data.ts';
+  }
+  if (readOptOut()) return 'visitor opted out';
+  if (isCaptureRun()) return 'headless capture run';
+  // Playwright and every other WebDriver-based runner sets this. The review harness loads exhibit
+  // pages dozens of times per run; counting those as visits would make the whole property useless.
+  if (navigator.webdriver) return 'automated browser (navigator.webdriver)';
+  if (debugForced) return null;
+  if (!ANALYTICS_HOSTS.includes(window.location.hostname)) {
+    return `host "${window.location.hostname}" is not a production host`;
+  }
+  return null;
+}
+
+let debugForced = false;
+let enabled = false;
+let initialized = false;
+
+export function isAnalyticsEnabled(): boolean {
+  return enabled;
+}
+
+/* -------------------------------------------------------------------------- loading */
+
+/**
+ * Loads gtag.js and configures the property. Safe to call once, from `main.ts`, before anything
+ * else renders — events fired before the script finishes downloading are not lost, because
+ * `dataLayer` is a plain array until gtag.js replaces it and drains what is already queued.
+ */
+export function initAnalytics(): void {
+  if (initialized) return;
+  initialized = true;
+
+  debugForced = urlFlag('analytics_debug') === '1';
+
+  // `?analytics=off` / `=on` is the opt-out the privacy drawer documents, honoured before anything
+  // is loaded so an opt-out link never causes a single measurement of its own.
+  const choice = urlFlag('analytics');
+  if (choice === 'off') setAnalyticsOptOut(true);
+  else if (choice === 'on') setAnalyticsOptOut(false);
+
+  const reason = disabledReason();
+  if (debugForced) {
+    // eslint-disable-next-line no-console
+    console.info(
+      reason ? `[analytics] disabled — ${reason}` : `[analytics] enabled — ${GA_MEASUREMENT_ID}`,
+    );
+  }
+  if (reason !== null) return;
+
+  loadGtag();
+  enabled = true;
+}
+
+/**
+ * The documented gtag.js snippet, as a function so the opt-out switch can call it too.
+ *
+ * `dataLayer` is a plain array until gtag.js replaces it, and gtag.js drains whatever is already
+ * queued — so an event fired during page mount, before the script has finished downloading, is not
+ * lost. That is why `initAnalytics` can be called before the first render.
+ */
+function loadGtag(): void {
+  window.dataLayer = window.dataLayer || [];
+  const gtag: (...args: unknown[]) => void = function gtag() {
+    // The documented snippet pushes `arguments` itself, not an array built from it: gtag.js reads
+    // the pushed objects back as Arguments, and an array does not deserialise the same way.
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer!.push(arguments);
+  };
+  window.gtag = gtag;
+
+  gtag('js', new Date());
+  gtag('config', GA_MEASUREMENT_ID, {
+    /**
+     * Manual, because this is a hash router and GA4 would get every route wrong on its own: it
+     * derives its page dimensions from `page_location` with the fragment STRIPPED, so `#/privacy`,
+     * `#/x/warrior` and `#/demo/awp-medusa-v2` would all report as `/` and the whole "where are
+     * people spending time" question would be unanswerable. `trackPageView` below sends a
+     * `page_location` with the route promoted out of the fragment into a real path instead.
+     */
+    send_page_view: false,
+    debug_mode: debugForced,
+  });
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(GA_MEASUREMENT_ID)}`;
+  document.head.appendChild(script);
+}
+
+/* --------------------------------------------------------------------------- sending */
+
+/**
+ * The one place an event leaves the site.
+ *
+ * `site_version` rides on every event explicitly rather than through `gtag('config')`: a report
+ * that cannot separate "v1.5.1 visitors" from "v1.6 visitors" cannot tell a regression from a
+ * change in the audience, and config-level parameter inheritance is not something to bet a whole
+ * property's data on.
+ */
+export function track(name: string, params: EventParams = {}): void {
+  if (!enabled || !window.gtag) return;
+
+  const payload: Record<string, string | number | boolean> = { site_version: CURRENT_VERSION };
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === '') continue;
+    if (Object.keys(payload).length >= MAX_PARAMS_PER_EVENT) break;
+    payload[key] = typeof value === 'string' ? clip(value) : value;
+  }
+
+  window.gtag('event', name, payload);
+  if (debugForced) {
+    // eslint-disable-next-line no-console
+    console.debug('[analytics]', name, payload);
+  }
+}
+
+/** One-shot guard for events that would otherwise fire on every frame or every scroll. */
+const fired = new Set<string>();
+
+function trackOnce(key: string, name: string, params: EventParams = {}): void {
+  if (fired.has(key)) return;
+  fired.add(key);
+  track(name, params);
+}
+
+/**
+ * Called when an exhibit loads, so its per-exhibit one-shots (first orbit) can fire again.
+ *
+ * Matched on the `viewer_interact:` prefix, not on the id alone: sponsor impression keys end in a
+ * sponsor id, and no sponsor is currently named after an exhibit — but "currently" is not a
+ * guarantee worth resting a silent data bug on.
+ */
+export function resetExhibitOnceKeys(exhibitId: string): void {
+  for (const key of [...fired]) {
+    if (key.startsWith('viewer_interact:') && key.endsWith(`:${exhibitId}`)) fired.delete(key);
+  }
+}
+
+/* ------------------------------------------------------------------------ page views */
+
+/**
+ * Promotes the hash route into the path GA4 will actually report on.
+ *
+ * `https://img2threejs.io/#/x/warrior` becomes `https://img2threejs.io/x/warrior`. The address bar
+ * is untouched — this is only the URL reported to GA4 — and it is the difference between a Pages
+ * report that lists every exhibit and content page, and one that lists `/` eleven thousand times.
+ */
+function reportableLocation(): string {
+  const { origin, pathname, hash, search } = window.location;
+  const route = hash.replace(/^#\/?/, '').split('?')[0];
+  const base = pathname.endsWith('/') ? pathname : `${pathname}/`;
+  return `${origin}${base}${route}${search}`;
+}
+
+export function trackPageView(title: string): void {
+  track('page_view', {
+    page_location: reportableLocation(),
+    page_title: clip(title),
+    page_referrer: document.referrer || undefined,
+  });
+}
+
+/* --------------------------------------------------------------------------- sponsors */
+
+/**
+ * Hostname → sponsor, so a sponsor link is attributed wherever it appears.
+ *
+ * This is what makes `tripoUrl` on a demo entry count for Tripo without every page having to
+ * remember that Tripo is a sponsor: the provenance link in the exhibit panel resolves through the
+ * same table as the card in the sponsor drawer, and both land in the same report row.
+ */
+function sponsorHosts(): Array<{ host: string; sponsor: SponsorEntry }> {
+  const rows: Array<{ host: string; sponsor: SponsorEntry }> = [];
+  for (const sponsor of SPONSORS) {
+    for (const host of [hostOf(sponsor.url), ...(sponsor.domains ?? [])]) {
+      if (host) rows.push({ host: host.replace(/^www\./, ''), sponsor });
+    }
+  }
+  return rows;
+}
+
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return null;
+  }
+}
+
+/** The sponsor a URL belongs to, or `null`. Matches subdomains, so `studio.tripo3d.ai` counts. */
+export function resolveSponsor(url: string): SponsorEntry | null {
+  const host = hostOf(url)?.replace(/^www\./, '');
+  if (!host) return null;
+  for (const { host: sponsorHost, sponsor } of sponsorHosts()) {
+    if (host === sponsorHost || host.endsWith(`.${sponsorHost}`)) return sponsor;
+  }
+  return null;
+}
+
+/**
+ * A sponsor's card was genuinely on screen. Deduplicated per sponsor per `round`, where the caller
+ * passes a value that changes each time the surface is reopened — otherwise scrolling a card out of
+ * view and back would inflate the denominator of every CTR we report.
+ */
+export function trackSponsorImpression(
+  sponsor: SponsorEntry,
+  placement: SponsorPlacement,
+  round: number,
+): void {
+  trackOnce(`sponsor_impression:${placement}:${round}:${sponsor.id}`, 'sponsor_impression', {
+    sponsor_id: sponsor.id,
+    sponsor_name: sponsor.name,
+    placement,
+  });
+}
+
+/** The event the sponsor report is built on. */
+export function trackSponsorClick(
+  sponsor: SponsorEntry,
+  placement: SponsorPlacement,
+  detail: { url: string; cta?: string; exhibitId?: string } = { url: '' },
+): void {
+  track('sponsor_click', {
+    sponsor_id: sponsor.id,
+    sponsor_name: sponsor.name,
+    placement,
+    link_url: detail.url || sponsor.url,
+    link_cta: detail.cta,
+    exhibit_id: detail.exhibitId,
+  });
+}
+
+/**
+ * Money that comes in without a logo attached: coffee, the VietQR/MoMo/PayPal page, GitHub
+ * Sponsors, Discord. Separate from `sponsor_click` so a logo sponsor's CTR is never diluted by
+ * donation traffic, and reported per channel because that is the only way to learn which channel
+ * a Vietnamese visitor and an overseas one each actually use.
+ */
+export type SupportChannel =
+  | 'buymeacoffee'
+  | 'donate_page'
+  | 'paypal'
+  | 'momo_vietqr'
+  | 'discord'
+  | 'github_sponsors'
+  | 'email';
+
+export function trackSupportClick(channel: SupportChannel, placement: string): void {
+  track('support_click', { channel, placement });
+}
+
+/* ------------------------------------------------------------------------- exhibits */
+
+export interface ExhibitFacts {
+  id: string;
+  title: string;
+  subjectClass: string;
+  status: string;
+  generatedWith: string;
+}
+
+/** How the visitor arrived at this exhibit. The single most useful parameter on the whole site. */
+export type ExhibitEntry =
+  | 'default'
+  | 'rail'
+  | 'arrow'
+  | 'keyboard'
+  | 'palette'
+  | 'deeplink'
+  | 'hashchange';
+
+export function trackExhibitView(
+  demo: ExhibitFacts,
+  entry: ExhibitEntry,
+  surface: Surface,
+): void {
+  track('exhibit_view', {
+    exhibit_id: demo.id,
+    exhibit_title: demo.title,
+    subject_class: demo.subjectClass,
+    exhibit_status: demo.status,
+    generated_with: demo.generatedWith,
+    entry,
+    surface,
+  });
+}
+
+/**
+ * The exhibit finished building and the viewer painted a real frame.
+ *
+ * `load_ms` is the number to watch: the two character exhibits precompute million-sample fields,
+ * and a visitor who leaves during that never becomes an `exhibit_ready` at all — so the gap
+ * between `exhibit_view` and `exhibit_ready` counts, per exhibit, is the abandonment rate for the
+ * slow ones. That is a product signal no amount of session-duration averaging will give you.
+ */
+export function trackExhibitReady(
+  demo: ExhibitFacts,
+  facts: { loadMs: number; triangles: number; partCount: number; prewarm: boolean },
+  surface: Surface,
+): void {
+  track('exhibit_ready', {
+    exhibit_id: demo.id,
+    exhibit_title: demo.title,
+    load_ms: Math.round(facts.loadMs),
+    triangles: facts.triangles,
+    part_count: facts.partCount,
+    prewarm: facts.prewarm,
+    surface,
+  });
+}
+
+export function trackExhibitPrewarmFailed(exhibitId: string, surface: Surface): void {
+  track('exhibit_prewarm_failed', { exhibit_id: exhibitId, surface });
+}
+
+/**
+ * The visitor actually touched the model, once per exhibit load. Orbiting fires continuously, so
+ * this is the first input only: what it answers is "did they engage with the 3D at all", and a
+ * per-frame version of that question would blow the property's event quota for no extra insight.
+ */
+export function trackViewerInteract(
+  exhibitId: string,
+  input: 'pointer' | 'wheel' | 'touch',
+  surface: Surface,
+): void {
+  trackOnce(`viewer_interact:${surface}:${exhibitId}`, 'viewer_interact', {
+    exhibit_id: exhibitId,
+    input,
+    surface,
+  });
+}
+
+export function trackAnimationPlay(
+  exhibitId: string,
+  action: { id: string; label: string },
+  surface: Surface,
+): void {
+  track('animation_play', {
+    exhibit_id: exhibitId,
+    action_id: action.id,
+    action_label: action.label,
+    surface,
+  });
+}
+
+export function trackAnimationStop(exhibitId: string, surface: Surface): void {
+  track('animation_stop', { exhibit_id: exhibitId, surface });
+}
+
+/**
+ * Explode is a slider in the workbench and a toggle in the viewer. Callers debounce: the slider
+ * emits an `input` event per pixel of travel, and one event per pixel is not a measurement.
+ */
+export function trackExplode(exhibitId: string, value: number, surface: Surface): void {
+  track('explode_use', {
+    exhibit_id: exhibitId,
+    // Two decimals: the slider's own resolution. A raw float would fragment the report into
+    // hundreds of near-identical values.
+    explode_value: Math.round(value * 100) / 100,
+    surface,
+  });
+}
+
+export function trackPartSelect(
+  exhibitId: string,
+  part: { name: string; kind: string; triangles: number },
+  surface: Surface,
+): void {
+  track('part_select', {
+    exhibit_id: exhibitId,
+    part_name: part.name,
+    part_kind: part.kind,
+    triangles: part.triangles,
+    surface,
+  });
+}
+
+export function trackPartIsolate(exhibitId: string, isolated: boolean, surface: Surface): void {
+  track('part_isolate', { exhibit_id: exhibitId, isolated, surface });
+}
+
+export function trackQualitySwitch(exhibitId: string, level: string): void {
+  track('quality_switch', { exhibit_id: exhibitId, quality_level: level });
+}
+
+/* ------------------------------------------------------------- navigation & reading */
+
+export function trackDrawerOpen(drawer: string, source: string): void {
+  track('drawer_open', { drawer, source });
+}
+
+/**
+ * `search` with `search_term` is GA4's own recommended pair, so the command palette shows up in the
+ * built-in site-search reporting instead of needing a custom report. The term is matched against a
+ * fixed list of exhibit titles; a palette that accepted free text about anything else would not be
+ * safe to report on.
+ */
+export function trackSearch(term: string, resultCount: number): void {
+  const trimmed = term.trim();
+  if (!trimmed) return;
+  track('search', { search_term: trimmed.toLowerCase(), result_count: resultCount });
+}
+
+export function trackPaletteOpen(source: 'button' | 'keyboard'): void {
+  track('palette_open', { source });
+}
+
+/** Which questions people actually open. The FAQ's own list of what the site failed to explain. */
+export function trackFaqOpen(index: number, question: string): void {
+  track('faq_open', { question_index: index, question: clip(question) });
+}
+
+export function trackSourceClick(exhibitId: string, surface: Surface): void {
+  track('source_click', { exhibit_id: exhibitId, surface });
+}
+
+export function trackOpenFullViewer(exhibitId: string): void {
+  track('open_full_viewer', { exhibit_id: exhibitId });
+}
+
+/**
+ * Any outbound link that is not a sponsor and not a support channel — GitHub, ArtStation, an
+ * author's profile, the licence. `placement` is required: knowing that 40 people left for GitHub is
+ * worth very little next to knowing whether they left from the exhibit panel or the About page.
+ */
+export function trackOutboundClick(detail: {
+  url: string;
+  label?: string;
+  placement: string;
+  exhibitId?: string;
+}): void {
+  track('outbound_click', {
+    link_url: detail.url,
+    link_domain: hostOf(detail.url) ?? undefined,
+    link_label: detail.label,
+    placement: detail.placement,
+    exhibit_id: detail.exhibitId,
+  });
+}
+
+/* ------------------------------------------------------- one entry point for a link */
+
+/**
+ * Classifies and reports any clicked link on the site, so a delegated click handler does not have
+ * to know the sponsor list or the payment channels.
+ *
+ * Order matters: a sponsor is checked first, because a sponsor click must never be double-counted
+ * as a generic outbound click — the sponsor CTR we report to a sponsor is the ratio of two events
+ * defined here, and a click that lands in both rows would make the two disagree.
+ *
+ * Support channels are matched on the URL rather than declared per link, because the same coffee
+ * and donate links appear in the sponsor drawer, the mobile menu and the donate page, and the
+ * channel is a property of the destination, not of where it was rendered.
+ */
+export function trackLinkClick(detail: {
+  url: string;
+  label?: string;
+  /** Where on the site the link was rendered. Required — an unplaced click barely answers anything. */
+  placement: string;
+  exhibitId?: string;
+  /** Passed by a sponsor card, which knows its own sponsor without a hostname lookup. */
+  sponsorId?: string;
+  /** Impression round, so a sponsor CTA click can be tied to the impression that preceded it. */
+  sponsorPlacement?: SponsorPlacement;
+}): void {
+  const { url, label, placement, exhibitId } = detail;
+
+  const sponsor = detail.sponsorId
+    ? SPONSORS.find((s) => s.id === detail.sponsorId) ?? resolveSponsor(url)
+    : resolveSponsor(url);
+  if (sponsor) {
+    trackSponsorClick(sponsor, detail.sponsorPlacement ?? sponsorPlacementFor(placement), {
+      url,
+      cta: label,
+      exhibitId,
+    });
+    return;
+  }
+
+  const channel = supportChannelFor(url);
+  if (channel) {
+    trackSupportClick(channel, placement);
+    return;
+  }
+
+  if (/^https?:/i.test(url)) {
+    trackOutboundClick({ url, label, placement, exhibitId });
+  }
+}
+
+/** Best-effort mapping from a UI placement string onto the sponsor placement vocabulary. */
+function sponsorPlacementFor(placement: string): SponsorPlacement {
+  if (placement.startsWith('drawer_sponsor')) return 'sponsor_drawer';
+  if (placement.startsWith('drawer_menu')) return 'menu_drawer';
+  if (placement.startsWith('demo')) return 'demo_provenance';
+  return 'sponsor_drawer';
+}
+
+function supportChannelFor(url: string): SupportChannel | null {
+  if (/^mailto:/i.test(url)) return 'email';
+  // The donate page is served from this domain, so it has no hostname to match on.
+  if (/donate\.html(?:[?#]|$)/i.test(url)) return 'donate_page';
+  const host = hostOf(url)?.replace(/^www\./, '');
+  if (!host) return null;
+  if (host === 'buymeacoffee.com') return 'buymeacoffee';
+  if (host === 'paypal.com' || host === 'paypal.me') return 'paypal';
+  if (host === 'discord.gg' || host.endsWith('discord.com')) return 'discord';
+  if (host === 'github.com' && /\/sponsors\//i.test(url)) return 'github_sponsors';
+  return null;
+}

--- a/src/capture-run.ts
+++ b/src/capture-run.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether this page load is a headless review/capture run rather than a human visit.
+ *
+ * The review harness (`scripts/capture-*.mjs`) loads `#/demo/<id>` with flags like `capture=1` /
+ * `back=1` / `mask=1` and screenshots as soon as the model reports ready. Two unrelated concerns
+ * need to agree on that answer — `main.ts` suppresses the intro overlay and the route cross-fade,
+ * and `analytics.ts` must not report a robot's page loads as traffic — so the test lives here
+ * rather than being written twice with a chance of drifting apart.
+ */
+const CAPTURE_FLAGS = ['capture', 'mask', 'back', 'bg', 'reviewWhite'] as const;
+
+export function isCaptureRun(): boolean {
+  // Flags ride on the hash (`#/demo/x?capture=1`) as often as on the real query string.
+  if (/[?&](capture|mask|back|bg|reviewWhite)=/.test(window.location.hash)) return true;
+  const search = new URLSearchParams(window.location.search);
+  return CAPTURE_FLAGS.some((key) => search.has(key));
+}

--- a/src/content.ts
+++ b/src/content.ts
@@ -9,6 +9,7 @@
  */
 
 import { demos } from './demos/registry';
+import { isOptedOut } from './analytics';
 import {
   ARROW_OUT,
   brand,
@@ -86,7 +87,7 @@ function roadmapDrawer(): string {
 function sponsorDrawer(): string {
   const logos = SPONSORS.map(
     (s) => `
-      <article class="sp-logo">
+      <article class="sp-logo" data-sponsor="${escapeAttr(s.id)}">
         <img src="${s.logo}" alt="${escapeAttr(s.name)}" loading="lazy" />
         <h3 class="sp-name">${escapeAttr(s.name)}</h3>
         <p class="sp-blurb">${escapeAttr(s.blurb)}</p>
@@ -104,14 +105,18 @@ function sponsorDrawer(): string {
       compute the reconstruction loop burns.
     </p>
     <div class="sp-grid">${logos}</div>
-    <div class="dr-actions">
+    <div class="dr-actions" data-placement="sponsor_support">
       <a class="btn btn-accent" href="${COFFEE_URL}" target="_blank" rel="noopener noreferrer">${HEART} Buy me a coffee</a>
       <a class="btn" href="${DONATE_URL}" target="_blank" rel="noopener noreferrer">VietQR &middot; MoMo &middot; PayPal</a>
       <a class="btn" href="${DISCORD_URL}" target="_blank" rel="noopener noreferrer">Join the Discord</a>
     </div>
     <p class="dr-note">
       Want your logo in this list? Write to
-      <a href="mailto:${CONTACT_EMAIL}">${CONTACT_EMAIL}</a>.
+      <a href="mailto:${CONTACT_EMAIL}">${CONTACT_EMAIL}</a>. Sponsors are sent an anonymous,
+      aggregate monthly count of how many times their card was seen and how many times it was
+      clicked &mdash; never anything about who did either. The
+      <button type="button" class="dr-inline-link" data-drawer="privacy">privacy page</button>
+      states exactly what is measured.
     </p>`;
 }
 
@@ -291,49 +296,127 @@ function attributionDrawer(): string {
 /* ------------------------------------------------------------------ privacy */
 
 function privacyDrawer(): string {
+  const optedOut = isOptedOut();
+
   return `
     <h2>Privacy</h2>
     <p class="dr-lede">
-      Short version: this site has no analytics, no cookies, no tracking, no advertising, and no
-      account of any kind. It never asks you for a single piece of personal information, because
-      there is nothing here that would use one.
+      Short version: this site measures how it is used, with Google Analytics. There is no
+      advertising, no account, no personal information asked for and nothing sold or shared with
+      anyone but the analytics provider that processes it. This page lists what is actually
+      collected, names the cookies, and gives you a switch to turn it off.
     </p>
 
-    <h3 class="dr-h3">What the page loads</h3>
     <p class="dr-copy">
-      Everything is bundled and served from this domain. The models are code that runs in your
-      browser, the fonts are the ones already on your system, and the page makes no request to any
-      third party &mdash; the safety check that runs on every contribution rejects
-      <span class="mono">fetch</span>, <span class="mono">XMLHttpRequest</span> and
-      <span class="mono">WebSocket</span> in exhibit code, so this holds for demos too. Outbound
-      links (GitHub, Discord, the sponsor and donation pages) reach those services only if you
-      click them.
+      This page used to say the site had no analytics at all, and for a while that was true. It
+      changed when the project took on logo sponsors: a sponsor paying for compute is owed evidence
+      of what their placement did, and &ldquo;trust us, people click it&rdquo; is not evidence. So the
+      claim changed rather than the page quietly staying as it was.
     </p>
 
-    <h3 class="dr-h3">The one thing stored on your device</h3>
+    <h3 class="dr-h3">What is measured</h3>
+    <p class="dr-copy">
+      Interactions with the site, sent to Google Analytics 4 as named events. The complete list is
+      in <a href="${GITHUB_SHOWCASE}/blob/main/src/analytics.ts" target="_blank" rel="noopener noreferrer">
+      one source file</a> &mdash; every event this site can send is a named function in it, so the
+      list below can be checked against the code rather than taken on faith:
+    </p>
+    <dl class="dr-defs">
+      <div><dt class="label">Navigation</dt><dd>Which route you open &mdash; an exhibit, the roadmap, this page &mdash; and how you got there (rail, arrow keys, search, a shared link)</dd></div>
+      <div><dt class="label">Exhibits</dt><dd>Which model, how long it took to build on your machine, whether it finished, and whether you orbited it at all</dd></div>
+      <div><dt class="label">Controls</dt><dd>Animations played, the explode slider, and which named part you selected</dd></div>
+      <div><dt class="label">Reading</dt><dd>Which content pages and which FAQ questions get opened</dd></div>
+      <div><dt class="label">Search</dt><dd>What you type into the exhibit palette (&#8984;K). It matches against a fixed list of exhibit titles; nothing else on the site accepts text</dd></div>
+      <div><dt class="label">Outbound clicks</dt><dd>Links to GitHub, Discord, ArtStation, the donation channels &mdash; and sponsor cards, which is the reason any of this exists</dd></div>
+      <div><dt class="label">From Google, not from us</dt><dd>Approximate location derived from your IP (country, region, city), device, browser, screen size, language, and the site that referred you</dd></div>
+    </dl>
+
+    <h3 class="dr-h3">What sponsors are told</h3>
+    <p class="dr-copy">
+      Two numbers per sponsor per month: how many times their card was on screen, and how many times
+      it was clicked. A card counts as seen when at least a quarter of it scrolls into view, once per
+      visit to the sponsor page &mdash; a deliberately conservative denominator, so the click-through
+      rate a sponsor is shown is not inflated by counting cards nobody scrolled to. Sponsors receive
+      totals and nothing else: no visitor, no session, no location, no list of who clicked.
+    </p>
+
+    <h3 class="dr-h3">What is not collected</h3>
+    <p class="dr-copy">
+      No name, email, or account &mdash; the site has no login and no form. No identifier of this
+      project's own making. Nothing you type anywhere except the exhibit search above. No
+      advertising features: Google Signals, ad personalisation and data sharing for ads are all off
+      on the property, so nothing here feeds cross-site ad profiling. Nothing is sold, and no data
+      is shared with any third party other than Google as the processor.
+    </p>
+
+    <h3 class="dr-h3">Cookies, named</h3>
+    <p class="dr-copy">
+      Google Analytics sets two first-party cookies on this domain: <span class="mono">_ga</span> and
+      <span class="mono">_ga_&lt;stream&nbsp;id&gt;</span>. They hold a randomly generated number that
+      lets a second page view be recognised as the same browser rather than a new one, they expire
+      two years after your last visit, and they are readable only by this domain. That is the whole
+      set &mdash; there is no advertising cookie, and Google Analytics 4 does not log or store IP
+      addresses. Event data is retained for 14 months on the property and then deleted by Google.
+    </p>
+
+    <h3 class="dr-h3">The one thing stored by the site itself</h3>
     <p class="dr-copy">
       A single <span class="mono">sessionStorage</span> entry,
       <span class="mono">img2threejs:intro-seen</span>, so the opening animation plays once per
       browser session instead of on every navigation. It holds the value
-      <span class="mono">"1"</span> and nothing else, it never leaves your device, and your browser
-      discards it when you close the tab. There are no cookies and no
-      <span class="mono">localStorage</span>.
+      <span class="mono">"1"</span>, it never leaves your device, and your browser discards it when
+      you close the tab. Turning analytics off with the switch below adds a second one,
+      <span class="mono">img2threejs:analytics-opt-out</span>, in
+      <span class="mono">localStorage</span> &mdash; the choice has to outlive the tab to be worth
+      anything.
     </p>
 
-    <h3 class="dr-h3">What the host can still see</h3>
+    <h3 class="dr-h3">The exhibits themselves still make no requests</h3>
     <p class="dr-copy">
-      Being straight about the limit of the claim: this site is served by GitHub Pages, and like any
-      web host GitHub receives your IP address and user agent in the ordinary course of delivering
-      the page. That is outside this project's control and is governed by GitHub's own privacy
-      statement. No such data is collected, requested or received by ${brand('img2threejs')}.
+      Worth separating from the above, because it is the claim this project actually stakes something
+      on: the models are code, and that code reaches the network never. The safety check that runs on
+      every contribution rejects <span class="mono">fetch</span>,
+      <span class="mono">XMLHttpRequest</span> and <span class="mono">WebSocket</span> in exhibit
+      code, and there are no imported meshes, no CDN and no remote fonts. The only third-party
+      request this site makes is the analytics script, and it is not involved in rendering anything.
     </p>
+
+    <h3 class="dr-h3">Who processes it</h3>
+    <p class="dr-copy">
+      Google, as the analytics provider &mdash; see
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google's privacy policy</a>
+      and
+      <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer">how Google uses data from sites that use its services</a>.
+      Separately, and as with any web host, GitHub Pages receives your IP address and user agent in
+      the ordinary course of delivering this page; that is governed by GitHub's own privacy
+      statement and is outside this project's control.
+    </p>
+
+    <h3 class="dr-h3">Turning it off</h3>
+    <p class="dr-copy">
+      ${optedOut
+        ? 'Analytics is <strong>off</strong> in this browser. Nothing is being sent, and the analytics script is not loaded.'
+        : 'Analytics is <strong>on</strong> in this browser. One click stops it, permanently, on this device.'}
+      The setting is stored on your device, not against any identity, so it applies to this browser
+      only. An ad blocker, tracker blocker or a browser that blocks
+      <span class="mono">googletagmanager.com</span> achieves the same thing and is not worked around
+      here.
+    </p>
+    <div class="dr-actions">
+      <button type="button" class="btn ${optedOut ? '' : 'btn-accent'}" data-analytics-toggle="${optedOut ? 'on' : 'off'}">
+        ${optedOut ? 'Turn analytics back on' : 'Turn analytics off in this browser'}
+      </button>
+    </div>
 
     <h3 class="dr-h3">Verify it yourself</h3>
     <p class="dr-copy">
-      Do not take the claim on trust &mdash; it is checkable in about thirty seconds. Open your
-      browser's developer tools, go to the Network panel, and reload this page: every request should
-      be to this domain. The Application panel will show the single session entry described above and
-      no cookies. The site's full source is public.
+      Do not take any of this on trust. Open your browser's developer tools, go to the Network panel
+      and reload: apart from <span class="mono">googletagmanager.com</span> and the
+      <span class="mono">/g/collect</span> requests it makes, every request should be to this domain.
+      Add <span class="mono">?analytics_debug=1</span> to the URL and the console prints every event
+      as it is sent, with its parameters &mdash; which is the fastest way to check that this page
+      describes what the code does. The Application panel will show the cookies and storage entries
+      named above and nothing else.
     </p>
 
     <p class="dr-note">
@@ -376,7 +459,7 @@ const FAQ: Array<[string, string]> = [
   ],
   [
     'Is the site tracking me?',
-    'No — no analytics, no cookies, no third-party requests. The privacy page explains exactly what is stored (one session flag) and, honestly, what the host can still see. It also tells you how to verify all of it in your own developer tools rather than believing the claim.',
+    'It measures you, and it should say so plainly: Google Analytics is installed, it sets two first-party cookies, and it records which exhibits you open, whether you orbit them, which pages you read and which outbound links you click. It exists for one reason — logo sponsors are owed evidence that their placement does something, and the whole sponsor report is two numbers per sponsor: card seen, card clicked. There is no advertising, no account, nothing you type except the exhibit search, and no data sold or shared with anyone but Google as the processor. The privacy page names the cookies, lists every event, gives you a switch to turn it off, and tells you how to verify all of it in your own developer tools. This answer used to be a flat "no", and changing it was the honest thing to do when the site changed.',
   ],
 ];
 
@@ -410,8 +493,11 @@ function aboutDrawer(): string {
     <h2>About &amp; contact</h2>
     <p class="dr-lede">
       Every model in this workbench is a TypeScript factory function. There are no imported meshes,
-      no downloaded art packs and no runtime network calls &mdash; the geometry is executed in your
-      browser from code that ${brand('img2threejs')} generated from a single reference photo.
+      no downloaded art packs and no network call anywhere in the rendering path &mdash; the geometry
+      is executed in your browser from code that ${brand('img2threejs')} generated from a single
+      reference photo. The site's one third-party request is its analytics script, which renders
+      nothing; the <button type="button" class="dr-inline-link" data-drawer="privacy">privacy
+      page</button> covers it.
     </p>
 
     <h3 class="dr-h3">This is the official site</h3>
@@ -456,7 +542,7 @@ function menuDrawer(): string {
     ['faq', 'FAQ', 'Straight answers, including the ones that are “ask a lawyer”'],
     ['sponsor', 'Sponsors', 'Who pays for the compute, and how to help'],
     ['attribution', 'Attribution', 'Whose designs these reconstructions belong to'],
-    ['privacy', 'Privacy', 'No analytics, no cookies — and how to verify that'],
+    ['privacy', 'Privacy', 'What analytics collects, the cookies it sets, and the switch to stop it'],
     ['about', 'About & contact', 'Official links, the maintainer, the licence'],
   ];
   return `

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,12 @@
 import './styles.css';
-import { currentRoute, onRouteChange } from './router';
+import { currentRoute, onRouteChange, type Route } from './router';
 import { renderWorkbench } from './pages/workbench';
 import { renderDemo } from './pages/demo';
 import { hasSeenIntro, runIntro } from './intro';
+import { isCaptureRun } from './capture-run';
+import { initAnalytics, trackPageView } from './analytics';
+import { getDemo } from './demos/registry';
+import { DRAWERS } from './content';
 
 const app = document.getElementById('app')!;
 
@@ -13,15 +17,17 @@ let pendingTransition: number | null = null;
 let mountedKind: 'workbench' | 'demo' | null = null;
 
 /**
- * The headless review harness loads `#/demo/<id>` with flags like `capture=1` / `back=1` / `mask=`
- * and screenshots as soon as the model reports ready, so nothing decorative may be on screen for
- * those runs — no intro overlay, no route cross-fade.
+ * The title reported to GA4 for a route, so the Pages report reads as a list of places on the site
+ * rather than eleven thousand rows of the one static `<title>` this single-document app ships with.
+ *
+ * Only ever a name already on screen — an exhibit title from the registry, a drawer's own heading —
+ * never anything derived from what a visitor typed.
  */
-function isCaptureRun(): boolean {
-  const hash = window.location.hash;
-  if (/[?&](capture|mask|back|bg|reviewWhite)=/.test(hash)) return true;
-  const search = new URLSearchParams(window.location.search);
-  return ['capture', 'mask', 'back', 'bg', 'reviewWhite'].some((key) => search.has(key));
+function routeTitle(route: Route): string {
+  if (route.name === 'demo') return `Viewer — ${getDemo(route.id)?.title ?? route.id}`;
+  if (route.name === 'workbench') return `Workbench — ${getDemo(route.id)?.title ?? route.id}`;
+  if (route.name === 'drawer') return DRAWERS[route.key]?.title ?? route.key;
+  return 'Workbench';
 }
 
 function mountRoute(): void {
@@ -90,5 +96,25 @@ function render(): void {
   }, ROUTE_TRANSITION_MS);
 }
 
+/**
+ * Before the first render, so an event fired during mount is queued on `dataLayer` rather than
+ * dropped. Sends nothing on a capture run, an automated browser, a non-production host, or for a
+ * visitor who has opted out — `analytics.ts` owns all four decisions.
+ */
+initAnalytics();
+
 onRouteChange(render);
 render();
+trackPageView(routeTitle(currentRoute()));
+
+/**
+ * Page views for the hash router, and the reason they are not inside `render()`: the workbench
+ * deliberately does NOT remount when it swaps exhibit or opens a drawer, so `render()` returns
+ * early for most route changes on the site. Listening to the route directly is what keeps
+ * `#/privacy`, `#/faq` and every `#/x/<exhibit>` in the Pages report.
+ *
+ * `replaceHashSilently` (the workbench's own URL writes) uses replaceState and fires no
+ * `hashchange`, so an in-place exhibit swap does not double-count here — the workbench sends its
+ * own `exhibit_view` for that, which is the event that actually describes what happened.
+ */
+onRouteChange((route) => trackPageView(routeTitle(route)));

--- a/src/pages/demo.ts
+++ b/src/pages/demo.ts
@@ -4,6 +4,21 @@ import { Viewer, type PartInfo } from '../scene';
 import { navigate } from '../router';
 import { brand, GITHUB_CORE as GITHUB_URL } from '../site-data';
 import { createLoader, whenViewerReady } from '../loader';
+import {
+  resetExhibitOnceKeys,
+  trackAnimationPlay,
+  trackAnimationStop,
+  trackExhibitPrewarmFailed,
+  trackExhibitReady,
+  trackExhibitView,
+  trackExplode,
+  trackLinkClick,
+  trackPartIsolate,
+  trackPartSelect,
+  trackQualitySwitch,
+  trackSourceClick,
+  trackViewerInteract,
+} from '../analytics';
 
 /** Viewports where the info panel becomes a collapsible bottom sheet over the model. */
 const COMPACT_QUERY = '(max-width: 860px), (max-height: 520px)';
@@ -30,6 +45,17 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
 
   const compact = window.matchMedia(COMPACT_QUERY);
   const expanded = panelExpanded ?? !compact.matches;
+  const startedAt = performance.now();
+  /**
+   * Always 'deeplink': `#/demo/<id>` is only ever reached from outside the workbench — a shared
+   * link, a README link, or the workbench's own "Open full viewer" button, which reports its own
+   * event before navigating. Nothing inside this page can change the exhibit without a reload.
+   *
+   * Unguarded by `capture`, because it does not need to be: a capture run is a headless browser on
+   * localhost, and `analytics.ts` refuses to send for either of those reasons on its own.
+   */
+  resetExhibitOnceKeys(demo.id);
+  trackExhibitView(demo, 'deeplink', 'viewer');
 
   mount.innerHTML = `
     <div class="demo-page">
@@ -95,7 +121,8 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
               <button class="btn btn-explode" id="demo-explode" type="button" aria-pressed="false" hidden>
                 <span class="explode-glyph">&#10021;</span> <span class="explode-label">Explode parts</span>
               </button>
-              <a class="btn" href="${demo.sourceUrl}" target="_blank" rel="noopener noreferrer">
+              <a class="btn" href="${demo.sourceUrl}" target="_blank" rel="noopener noreferrer"
+                 data-track-skip>
                 &lt;/&gt; View generated source
               </a>
               ${demo.tripoUrl ? `
@@ -196,7 +223,10 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
       button.textContent = action.label;
       button.setAttribute('aria-pressed', 'false');
       button.title = action.loop ? `${action.label} (loops until stopped)` : `${action.label} (plays once)`;
-      const onClick = (): void => animationController.play(action.id);
+      const onClick = (): void => {
+        animationController.play(action.id);
+        trackAnimationPlay(demo.id, action, 'viewer');
+      };
       button.addEventListener('click', onClick);
       animationButtonCleanups.push(() => button.removeEventListener('click', onClick));
       animationButtons.appendChild(button);
@@ -207,7 +237,10 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
     stopButton.className = 'btn demo-animation-btn demo-animation-stop';
     stopButton.dataset.animation = 'stop';
     stopButton.textContent = 'Stop / Reset';
-    const onStop = (): void => animationController.stop();
+    const onStop = (): void => {
+      animationController.stop();
+      trackAnimationStop(demo.id, 'viewer');
+    };
     stopButton.addEventListener('click', onStop);
     animationButtonCleanups.push(() => stopButton.removeEventListener('click', onStop));
     animationButtons.appendChild(stopButton);
@@ -253,6 +286,9 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
       button.setAttribute('aria-pressed', String(selected));
       if (selected && status) status.value = option.note;
       button.addEventListener('click', () => {
+        // Sent before the navigation: switching detail level reloads the page, so an event queued
+        // after `location.href` is assigned may never leave the browser.
+        trackQualitySwitch(demo.id, option.id);
         const url = new URL(window.location.href);
         url.searchParams.delete('lod');
         url.searchParams.delete('sdf');
@@ -331,6 +367,7 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
     let exploded = false;
     explodeBtn.addEventListener('click', () => {
       exploded = !exploded;
+      trackExplode(demo.id, exploded ? 1 : 0, 'viewer');
       viewer.setExplode(exploded ? 1 : 0);
       explodeBtn.setAttribute('aria-pressed', String(exploded));
       explodeBtn.classList.toggle('is-active', exploded);
@@ -383,7 +420,10 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
     isolateBtn.type = 'button';
     isolateBtn.setAttribute('aria-pressed', String(viewer.isolated));
     // No manual re-render: setIsolate reports back through onSelect.
-    isolateBtn.addEventListener('click', () => viewer.setIsolate(!viewer.isolated));
+    isolateBtn.addEventListener('click', () => {
+      trackPartIsolate(demo.id, !viewer.isolated, 'viewer');
+      viewer.setIsolate(!viewer.isolated);
+    });
     const clearBtn = el('button', 'btn part-btn', 'Clear');
     clearBtn.type = 'button';
     clearBtn.addEventListener('click', () => {
@@ -465,7 +505,10 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
     // replaces the buttons but would stack a second identical handler on the list itself.
     partsList.addEventListener('click', (e) => {
       const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.part-item');
-      if (btn?.dataset.part) viewer.selectByName(btn.dataset.part);
+      if (!btn?.dataset.part) return;
+      viewer.selectByName(btn.dataset.part);
+      const part = viewer.parts.find((candidate) => candidate.name === btn.dataset.part);
+      if (part) trackPartSelect(demo.id, part, 'viewer');
     });
 
     populateParts();
@@ -478,7 +521,12 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
       // `finally`, not `then`. A prewarm that REJECTS still changes the scene -- girl-character falls
       // back to its cross-section loft -- and running the UI sync only on success left that fallback
       // with no parts panel and no explode button at all.
-      void demo.prewarm().catch(() => { /* the demo logs its own reason */ }).finally(() => {
+      void demo.prewarm().catch(() => {
+        /* the demo logs its own reason */
+        // Reported from this catch and not the loader's below: `prewarm` caches and resolves the
+        // same promise for both, so tracking it in both places would double-count one failure.
+        trackExhibitPrewarmFailed(demo.id, 'viewer');
+      }).finally(() => {
         viewer.rebuildParts();
         populateParts();
         syncExplodeButton();
@@ -550,7 +598,22 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
         loader.phase('Framing');
         return whenViewerReady();
       })
-      .then(() => loader.done());
+      .then(() => {
+        loader.done();
+        const manifest = viewer.partManifest();
+        trackExhibitReady(
+          demo,
+          {
+            loadMs: performance.now() - startedAt,
+            triangles: manifest
+              ? manifest.parts.reduce((sum, part) => sum + part.triangles, 0)
+              : 0,
+            partCount: manifest ? manifest.parts.length : 0,
+            prewarm: !!demo.prewarm,
+          },
+          'viewer',
+        );
+      });
   }
 
   // --- collapsible details sheet ---------------------------------------------------------
@@ -583,11 +646,54 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
   const hintTimer = window.setTimeout(hideHint, 6000);
   canvasMount.addEventListener('pointerdown', hideHint, { once: true });
 
+  /* --- measurement ------------------------------------------------------------------------
+   *
+   * Two handlers, both delegated, both removed in the cleanup below.
+   *
+   * The link handler is the reason the Tripo provenance link on an exhibit counts for Tripo without
+   * this file knowing that Tripo is a sponsor: `trackLinkClick` resolves the destination's hostname
+   * against the sponsor list, so a sponsor's own asset page lands in the same report row as their
+   * card in the sponsor drawer. Add another provenance link tomorrow and it is attributed with no
+   * change here. `data-track-skip` marks the source link, which sends a richer event of its own.
+   */
+  const reportFirstInput = (input: 'pointer' | 'wheel' | 'touch') => (): void => {
+    trackViewerInteract(demo.id, input, 'viewer');
+  };
+  const onFirstPointer = reportFirstInput('pointer');
+  const onFirstWheel = reportFirstInput('wheel');
+  const onFirstTouch = reportFirstInput('touch');
+  canvasMount.addEventListener('pointerdown', onFirstPointer);
+  canvasMount.addEventListener('wheel', onFirstWheel, { passive: true });
+  canvasMount.addEventListener('touchstart', onFirstTouch, { passive: true });
+
+  const onPanelLinkClick = (event: MouseEvent): void => {
+    const anchor = (event.target as HTMLElement).closest<HTMLAnchorElement>('a[href]');
+    if (!anchor) return;
+    const href = anchor.getAttribute('href') ?? '';
+    if (anchor.hasAttribute('data-track-skip')) {
+      trackSourceClick(demo.id, 'viewer');
+      return;
+    }
+    // `#/` is the back link. The route it leads to reports its own page view.
+    if (!href || href.startsWith('#')) return;
+    trackLinkClick({
+      url: anchor.href,
+      label: anchor.textContent?.trim().replace(/\s+/g, ' '),
+      placement: 'demo_panel',
+      exhibitId: demo.id,
+    });
+  };
+  mount.addEventListener('click', onPanelLinkClick);
+
   return () => {
     window.clearTimeout(hintTimer);
     bar.removeEventListener('click', onBarClick);
     compact.removeEventListener('change', onCompactChange);
     canvasMount.removeEventListener('pointerdown', hideHint);
+    canvasMount.removeEventListener('pointerdown', onFirstPointer);
+    canvasMount.removeEventListener('wheel', onFirstWheel);
+    canvasMount.removeEventListener('touchstart', onFirstTouch);
+    mount.removeEventListener('click', onPanelLinkClick);
     animationController?.stop();
     unsubscribeAnimation?.();
     for (const cleanup of animationButtonCleanups) cleanup();

--- a/src/pages/workbench.ts
+++ b/src/pages/workbench.ts
@@ -3,7 +3,29 @@ import { Viewer, type PartInfo } from '../scene';
 import { parseRoute, replaceHashSilently } from '../router';
 import { createLoader, whenViewerReady, type Loader } from '../loader';
 import { DRAWERS } from '../content';
-import { brand, CURRENT_VERSION, GITHUB_CORE } from '../site-data';
+import { brand, CURRENT_VERSION, GITHUB_CORE, SPONSORS } from '../site-data';
+import {
+  trackAnimationPlay,
+  trackAnimationStop,
+  trackDrawerOpen,
+  trackExhibitPrewarmFailed,
+  trackExhibitReady,
+  trackExhibitView,
+  trackExplode,
+  trackFaqOpen,
+  trackLinkClick,
+  trackOpenFullViewer,
+  trackPageView,
+  trackPaletteOpen,
+  trackPartSelect,
+  trackSearch,
+  trackSourceClick,
+  trackSponsorImpression,
+  trackViewerInteract,
+  resetExhibitOnceKeys,
+  setAnalyticsOptOut,
+  type ExhibitEntry,
+} from '../analytics';
 
 const VERSION_TAG = /v\d+(?:\.\d+){0,2}(?:-[a-z0-9.]+)?/i;
 
@@ -122,7 +144,7 @@ export function renderWorkbench(
           <p class="wb-blurb" id="wb-blurb"></p>
           <div class="wb-caption-actions">
             <a class="btn btn-accent" id="wb-open-full" href="#/demo/${initial.id}">Open full viewer</a>
-            <a class="btn" id="wb-open-source" href="${initial.sourceUrl}" target="_blank" rel="noopener noreferrer">Read the source</a>
+            <a class="btn" id="wb-open-source" href="${initial.sourceUrl}" target="_blank" rel="noopener noreferrer" data-track-skip>Read the source</a>
           </div>
         </section>
 
@@ -208,6 +230,19 @@ export function renderWorkbench(
   /** Bumped on every load; an async prewarm that resolves after a newer load started is discarded. */
   let loadToken = 0;
   let disposed = false;
+  /**
+   * False until the initial synchronous mount has finished. `main.ts` sends the first `page_view`
+   * for whatever route this mount settles on, so the exhibit load and the deep-linked drawer that
+   * run during mount must not each send one of their own — the same visit would be three pages.
+   */
+  let booted = false;
+  /**
+   * Incremented every time the sponsor drawer is opened. Sponsor impressions are deduplicated per
+   * round, so a visitor who scrolls a card out of view and back is one impression, while a visitor
+   * who genuinely returns to the sponsor page later is a second — which is the distinction a CTR
+   * reported to a sponsor stands or falls on.
+   */
+  let sponsorRound = 0;
 
   const teardownViewer = (): void => {
     unsubscribeAnimation?.();
@@ -267,11 +302,16 @@ export function renderWorkbench(
 
   /* ------------------------------------------------------------------- load */
 
-  async function loadExhibit(nextIndex: number): Promise<void> {
+  async function loadExhibit(nextIndex: number, entry: ExhibitEntry = 'rail'): Promise<void> {
     const demo = demos[nextIndex];
     if (!demo || disposed) return;
     const token = ++loadToken;
     index = nextIndex;
+    const startedAt = performance.now();
+    // First-orbit is measured once per exhibit LOAD, not once per page: coming back to an exhibit
+    // and orbiting it again is a fresh engagement signal.
+    resetExhibitOnceKeys(demo.id);
+    trackExhibitView(demo, entry, 'workbench');
 
     // Rail + copy update immediately, so the UI answers the click before geometry exists.
     for (const b of railTrack.querySelectorAll<HTMLButtonElement>('.rail-item')) {
@@ -288,6 +328,14 @@ export function renderWorkbench(
     openFull.href = `#/demo/${demo.id}`;
     openSource.href = demo.sourceUrl;
     replaceHashSilently(`#/x/${demo.id}`);
+    // `replaceHashSilently` fires no `hashchange`, so the listener in `main.ts` never sees an
+    // in-place exhibit swap. Without this, the standard Pages report would credit every exhibit on
+    // the site to whichever one the visitor happened to land on first.
+    //
+    // Except when the swap CAME FROM a hashchange — a back/forward step — because that is the one
+    // case the listener in `main.ts` did see and has already counted. Same guard the drawer path
+    // spells as `syncUrl`: whoever owns the URL change owns the page view.
+    if (booted && entry !== 'hashchange') trackPageView(`Workbench — ${demo.title}`);
 
     setSpecs([
       ['Generated with', demo.generatedWith],
@@ -320,6 +368,7 @@ export function renderWorkbench(
         await demo.prewarm();
       } catch {
         /* a failed prewarm still lets build() run, just slower */
+        trackExhibitPrewarmFailed(demo.id, 'workbench');
       }
       if (token !== loadToken || disposed) return;
       loader?.phase('Building geometry');
@@ -364,7 +413,23 @@ export function renderWorkbench(
     const ownLoader = loader;
     ownLoader?.phase('Framing');
     void whenViewerReady().then(() => {
-      if (token === loadToken && !disposed) ownLoader?.done();
+      if (token !== loadToken || disposed) return;
+      ownLoader?.done();
+      // Reported here rather than after `build()` because this is the moment the visitor can see
+      // something: it includes prewarm, geometry, texture decode and shader compile.
+      const readyManifest = v.partManifest();
+      trackExhibitReady(
+        demo,
+        {
+          loadMs: performance.now() - startedAt,
+          triangles: readyManifest
+            ? readyManifest.parts.reduce((sum, part) => sum + part.triangles, 0)
+            : 0,
+          partCount: readyManifest ? readyManifest.parts.length : 0,
+          prewarm: !!demo.prewarm,
+        },
+        'workbench',
+      );
     });
 
     const manifest = v.partManifest();
@@ -403,8 +468,13 @@ export function renderWorkbench(
         b.textContent = action.label;
         b.title = action.loop ? `${action.label} (loops)` : `${action.label} (plays once)`;
         b.addEventListener('click', () => {
-          if (controller.active === action.id) controller.stop();
-          else controller.play(action.id);
+          if (controller.active === action.id) {
+            controller.stop();
+            trackAnimationStop(demo.id, 'workbench');
+          } else {
+            controller.play(action.id);
+            trackAnimationPlay(demo.id, action, 'workbench');
+          }
         });
         buttons.set(action.id, b);
         animActions.appendChild(b);
@@ -432,19 +502,33 @@ export function renderWorkbench(
   on(railTrack, 'click', (e: Event) => {
     const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.rail-item');
     if (!btn?.dataset.index) return;
-    void loadExhibit(Number(btn.dataset.index));
+    void loadExhibit(Number(btn.dataset.index), 'rail');
   });
 
-  const step = (delta: number): void => {
-    void loadExhibit((index + delta + demos.length) % demos.length);
+  const step = (delta: number, entry: ExhibitEntry = 'arrow'): void => {
+    void loadExhibit((index + delta + demos.length) % demos.length, entry);
   };
   on(mount.querySelector<HTMLElement>('#rail-prev')!, 'click', () => step(-1));
   on(mount.querySelector<HTMLElement>('#rail-next')!, 'click', () => step(1));
 
+  /**
+   * The slider emits an `input` event per pixel of travel. Reporting each one would spend the
+   * property's event quota on a single drag and tell us nothing the settled value does not, so only
+   * where the visitor let go is measured.
+   */
+  let explodeReportTimer: number | null = null;
   on(explodeRange, 'input', () => {
     const t = Number(explodeRange.value);
     explodeOut.value = t.toFixed(2);
     viewer?.setExplode(t);
+    if (explodeReportTimer !== null) window.clearTimeout(explodeReportTimer);
+    explodeReportTimer = window.setTimeout(() => {
+      explodeReportTimer = null;
+      if (t > 0) trackExplode(demos[index].id, t, 'workbench');
+    }, 700);
+  });
+  cleanups.push(() => {
+    if (explodeReportTimer !== null) window.clearTimeout(explodeReportTimer);
   });
 
   on(partList, 'click', (e: Event) => {
@@ -452,7 +536,23 @@ export function renderWorkbench(
     if (!btn?.dataset.part) return;
     const already = btn.classList.contains('is-active');
     viewer?.selectByName(already ? null : btn.dataset.part);
+    if (!already) {
+      const part = viewer?.partManifest()?.parts.find((candidate) => candidate.name === btn.dataset.part);
+      if (part) trackPartSelect(demos[index].id, part, 'workbench');
+    }
   });
+
+  /**
+   * Did the visitor actually touch the model? Answered once per exhibit load, from the canvas's own
+   * first input — this is the difference between "the exhibit was on screen" and "the exhibit was
+   * used", and it is the number that says whether the 3D is doing its job at all.
+   */
+  const reportFirstInput = (input: 'pointer' | 'wheel' | 'touch') => (): void => {
+    trackViewerInteract(demos[index].id, input, 'workbench');
+  };
+  on(canvasMount, 'pointerdown', reportFirstInput('pointer'));
+  on(canvasMount, 'wheel', reportFirstInput('wheel'), { passive: true });
+  on(canvasMount, 'touchstart', reportFirstInput('touch'), { passive: true });
 
   /* ---- drawers ---- */
   let openDrawer: string | null = null;
@@ -473,7 +573,7 @@ export function renderWorkbench(
    * `syncUrl` is false only when the caller IS the URL — i.e. this open came from a deep link or a
    * back/forward step, so writing the hash again would be circular.
    */
-  const showDrawer = (key: string, syncUrl = true): void => {
+  const showDrawer = (key: string, source: string, syncUrl = true): void => {
     const entry = DRAWERS[key];
     if (!entry) return;
     if (openDrawer === key) {
@@ -482,6 +582,9 @@ export function renderWorkbench(
     }
     openDrawer = key;
     drawerBody.innerHTML = entry.build();
+    // Every link inside a drawer inherits its placement from the drawer it is in, so the delegated
+    // click handler below does not need a per-link annotation to say where a click came from.
+    drawerBody.dataset.placement = `drawer_${key}`;
     drawer.hidden = false;
     palette.hidden = true;
     scrim.hidden = false;
@@ -490,17 +593,150 @@ export function renderWorkbench(
     mount.querySelector<HTMLElement>('#wb-drawer-close')?.focus();
     // Content pages are linkable: /#/privacy has to survive being copied out of the address bar.
     if (syncUrl) replaceHashSilently(`#/${key}`);
+
+    trackDrawerOpen(key, source);
+    // `replaceHashSilently` fires no `hashchange`, so a drawer opened by tapping a nav button is
+    // invisible to the page-view listener in `main.ts`. Deep links and back/forward steps arrive
+    // with `syncUrl` false, and those the listener has already counted.
+    if (booted && syncUrl) trackPageView(entry.title);
+    if (key === 'sponsor') watchSponsorImpressions();
   };
+
+  /**
+   * Sponsor impressions, measured from the card actually being on screen rather than from the
+   * drawer being opened.
+   *
+   * This is the denominator of the click-through rate a sponsor is sent, so it has to mean
+   * something: a visitor who opens the sponsor page and closes it without scrolling has seen the
+   * first card and not the third, and reporting three impressions for that would overstate reach
+   * and understate CTR for every sponsor below the fold.
+   *
+   * 25% of the card, once, per opening. Not the IAB display-ad standard (50% for one continuous
+   * second) on purpose: these are prose cards that can stand taller than a phone's drawer, where a
+   * 50% threshold would never fire at all and the sponsor at the bottom would look unseen rather
+   * than unscrolled. `docs/ANALYTICS.md` states this in the same words, so a sponsor being sent the
+   * number is told what it counts.
+   */
+  let sponsorObserver: IntersectionObserver | null = null;
+
+  function watchSponsorImpressions(): void {
+    sponsorObserver?.disconnect();
+    sponsorObserver = null;
+    const cards = Array.from(drawerBody.querySelectorAll<HTMLElement>('[data-sponsor]'));
+    if (cards.length === 0) return;
+
+    const round = ++sponsorRound;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          const card = entry.target as HTMLElement;
+          const sponsor = SPONSORS.find((candidate) => candidate.id === card.dataset.sponsor);
+          if (sponsor) trackSponsorImpression(sponsor, 'sponsor_drawer', round);
+          // Stop watching a card that has been counted: the dedupe in `analytics.ts` would drop the
+          // repeat anyway, but there is no reason to keep paying for the callback.
+          observer.unobserve(card);
+        }
+      },
+      { root: drawer, threshold: 0.25 },
+    );
+    for (const card of cards) observer.observe(card);
+    sponsorObserver = observer;
+  }
+  cleanups.push(() => sponsorObserver?.disconnect());
 
   /**
    * Delegated at the root rather than bound per button: the menu drawer's own entries are
    * `[data-drawer]` buttons that do not exist until that drawer is built, so a one-time query over
    * the initial markup would have wired the top bar and left every menu item dead.
    */
+  /** Which control opened a drawer. `Sponsor` in the top bar and `Sponsors` in the nav are the same
+   *  drawer reached two different ways, and knowing which one people use is how the CTA earns its
+   *  place in the header. */
+  const drawerSource = (btn: HTMLElement): string => {
+    if (btn.classList.contains('wb-sponsor')) return 'header_cta';
+    if (btn.classList.contains('wb-navlink')) return 'header_nav';
+    if (btn.classList.contains('wb-menu')) return 'menu_button';
+    if (btn.classList.contains('mn-item')) return 'menu_drawer';
+    return 'other';
+  };
+
   on(mount, 'click', (e: Event) => {
     const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-drawer]');
-    if (btn?.dataset.drawer) showDrawer(btn.dataset.drawer);
+    if (btn?.dataset.drawer) showDrawer(btn.dataset.drawer, drawerSource(btn));
   });
+
+  /**
+   * The opt-out switch on the privacy page. Rebuilds the drawer afterwards so the page states the
+   * choice that is now in force — a privacy control that leaves you guessing whether it took effect
+   * is not much of a control. `setAnalyticsOptOut` applies immediately, without a reload.
+   */
+  on(mount, 'click', (e: Event) => {
+    const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-analytics-toggle]');
+    if (!btn) return;
+    setAnalyticsOptOut(btn.dataset.analyticsToggle === 'off');
+    const privacy = DRAWERS.privacy;
+    if (openDrawer === 'privacy' && privacy) drawerBody.innerHTML = privacy.build();
+  });
+
+  /**
+   * Every outbound link on the page, in one handler.
+   *
+   * Delegated rather than bound per link because drawer content is rebuilt from a string each time
+   * it opens — a sponsor CTA, a mailto, a Discord invite and a licence link do not exist until then.
+   * `trackLinkClick` decides whether a destination is a sponsor, a support channel or a plain
+   * outbound click, so this stays a routing decision about WHERE the click happened.
+   */
+  const placementFor = (anchor: HTMLElement): string => {
+    const declared = anchor.closest<HTMLElement>('[data-placement]')?.dataset.placement;
+    if (declared) return declared;
+    if (anchor.closest('.wb-top')) return 'header';
+    if (anchor.closest('.wb-caption')) return 'exhibit_caption';
+    return 'other';
+  };
+
+  on(mount, 'click', (e: Event) => {
+    const anchor = (e.target as HTMLElement).closest<HTMLAnchorElement>('a[href]');
+    if (!anchor || anchor.hasAttribute('data-track-skip')) return;
+    const href = anchor.getAttribute('href') ?? '';
+    // In-site navigation. The route it leads to reports itself as a page view, and the two links
+    // that deserve more than that (`Open full viewer`, `Read the source`) have their own events.
+    if (!href || href.startsWith('#')) return;
+
+    const card = anchor.closest<HTMLElement>('[data-sponsor]');
+    trackLinkClick({
+      url: anchor.href,
+      label: anchor.textContent?.trim().replace(/\s+/g, ' '),
+      placement: placementFor(anchor),
+      sponsorId: card?.dataset.sponsor,
+      // An exhibit is only context for a link rendered over the exhibit itself; a sponsor click
+      // from inside the privacy page has nothing to do with whatever model is loaded behind it.
+      exhibitId: drawerBody.contains(anchor) ? undefined : demos[index].id,
+    });
+  });
+
+  /**
+   * Which FAQ answers get opened — the site's own list of what it failed to explain up front.
+   *
+   * `toggle` does not bubble, so this listens in the CAPTURE phase: a capture-phase listener on an
+   * ancestor still receives a non-bubbling event, which is what makes one delegated handler work
+   * for questions that are rebuilt from a string every time the drawer opens.
+   */
+  on(
+    drawerBody,
+    'toggle',
+    (e: Event) => {
+      const details = e.target as HTMLElement;
+      if (!(details instanceof HTMLDetailsElement) || !details.open) return;
+      if (!details.classList.contains('faq-item')) return;
+      const items = Array.from(drawerBody.querySelectorAll<HTMLElement>('.faq-item'));
+      trackFaqOpen(
+        items.indexOf(details) + 1,
+        details.querySelector('summary')?.textContent?.trim() ?? '',
+      );
+    },
+    { capture: true },
+  );
   on(mount.querySelector<HTMLElement>('#wb-drawer-close')!, 'click', closeOverlays);
   on(scrim, 'click', closeOverlays);
 
@@ -537,7 +773,8 @@ export function renderWorkbench(
       : `<li class="pal-empty">No exhibit matches that.</li>`;
   };
 
-  const openPalette = (): void => {
+  const openPalette = (source: 'button' | 'keyboard'): void => {
+    trackPaletteOpen(source);
     palette.hidden = false;
     drawer.hidden = true;
     openDrawer = null;
@@ -554,14 +791,31 @@ export function renderWorkbench(
     const target = id ?? matches[palIndex]?.id;
     if (!target) return;
     const i = demos.findIndex((d) => d.id === target);
-    if (i >= 0) void loadExhibit(i);
+    if (i >= 0) void loadExhibit(i, 'palette');
     closeOverlays();
   };
 
-  on(mount.querySelector<HTMLElement>('#wb-open-palette')!, 'click', openPalette);
+  on(openFull, 'click', () => trackOpenFullViewer(demos[index].id));
+  on(openSource, 'click', () => trackSourceClick(demos[index].id, 'workbench'));
+
+  on(mount.querySelector<HTMLElement>('#wb-open-palette')!, 'click', () => openPalette('button'));
+  /**
+   * Reported as GA4's own `search` event so the palette shows up in the built-in site-search
+   * reporting, and debounced to the settled query: sending a measurement per keystroke would turn
+   * one search for "medusa" into six rows reading m, me, med, medu, medus, medusa.
+   */
+  let searchReportTimer: number | null = null;
   on(palInput, 'input', () => {
     palIndex = 0;
     drawPalette();
+    if (searchReportTimer !== null) window.clearTimeout(searchReportTimer);
+    searchReportTimer = window.setTimeout(() => {
+      searchReportTimer = null;
+      trackSearch(palInput.value, palMatches().length);
+    }, 900);
+  });
+  cleanups.push(() => {
+    if (searchReportTimer !== null) window.clearTimeout(searchReportTimer);
   });
   on(palList, 'click', (e: Event) => {
     const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.pal-item');
@@ -573,7 +827,7 @@ export function renderWorkbench(
 
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
       e.preventDefault();
-      if (palette.hidden) openPalette();
+      if (palette.hidden) openPalette('keyboard');
       else closeOverlays();
       return;
     }
@@ -599,8 +853,8 @@ export function renderWorkbench(
     }
     // Arrow keys walk the rail, but never while typing or with a drawer in front.
     if (inField || openDrawer) return;
-    if (e.key === 'ArrowLeft') step(-1);
-    else if (e.key === 'ArrowRight') step(1);
+    if (e.key === 'ArrowLeft') step(-1, 'keyboard');
+    else if (e.key === 'ArrowRight') step(1, 'keyboard');
   });
 
   /**
@@ -614,13 +868,13 @@ export function renderWorkbench(
     const route = parseRoute(window.location.hash);
     if (route.name === 'drawer') {
       // `false`: the URL is already what it should be — this open came FROM it.
-      showDrawer(route.key, false);
+      showDrawer(route.key, 'deeplink', false);
       return;
     }
     if (route.name === 'workbench') {
       if (openDrawer) closeOverlays();
       const target = demos.findIndex((d) => d.id === route.id);
-      if (target >= 0 && target !== index) void loadExhibit(target);
+      if (target >= 0 && target !== index) void loadExhibit(target, 'hashchange');
       return;
     }
     if (route.name === 'home' && openDrawer) closeOverlays();
@@ -628,7 +882,7 @@ export function renderWorkbench(
 
   /* ------------------------------------------------------------------ start */
   railCount.textContent = `${String(index + 1).padStart(2, '0')} / ${demos.length}`;
-  void loadExhibit(index);
+  void loadExhibit(index, focusId ? 'deeplink' : 'default');
   // A deep link straight to a content page opens it over the workbench, which keeps loading behind
   // it — the reader gets the page immediately and the exhibit is already there when they close it.
   //
@@ -636,7 +890,12 @@ export function renderWorkbench(
   // already replaced the hash with its exhibit synchronously. Skipping the write left a visitor who
   // opened /#/how-it-works looking at /#/x/awp-medusa-v2, so the link they were about to share no
   // longer pointed at the page they were reading.
-  if (initialDrawer) showDrawer(initialDrawer);
+  if (initialDrawer) showDrawer(initialDrawer, 'deeplink');
+
+  // Everything above is the initial mount, which `main.ts` reports as one page view for whatever
+  // route it settles on. From here on, an exhibit swap or a drawer opening is a navigation of its
+  // own and reports itself.
+  booted = true;
 
   return () => {
     disposed = true;

--- a/src/site-data.ts
+++ b/src/site-data.ts
@@ -48,7 +48,7 @@ export const CURRENT_VERSION = 'v1.5.1';
  * all and says why in the console under `?analytics_debug=1`.
  */
 export const GA_MEASUREMENT_ID_PLACEHOLDER = 'G-XXXXXXXXXX';
-export const GA_MEASUREMENT_ID: string = GA_MEASUREMENT_ID_PLACEHOLDER;
+export const GA_MEASUREMENT_ID: string = 'G-7GXMDHK2DE';
 
 /**
  * Hostnames allowed to send measurements, so `localhost`, a `vite preview`, a fork's Pages build

--- a/src/site-data.ts
+++ b/src/site-data.ts
@@ -35,6 +35,28 @@ export const CONTACT_EMAIL = 'hoainho.work@gmail.com';
 export const CONTACT_NAME = 'Nick';
 export const CURRENT_VERSION = 'v1.5.1';
 
+/* --------------------------------------------------------------------------- analytics */
+
+/**
+ * The GA4 measurement ID, committed in the clear on purpose: it is not a secret. Every visitor
+ * receives it in the page anyway, Google's own install instructions put it in the HTML, and the
+ * alternative — a build secret — would mean the ID is absent from local builds and PR previews,
+ * which is exactly where an analytics change needs to be testable.
+ *
+ * Replace the placeholder with the property's real ID (Admin → Data streams → your stream → the
+ * `G-` prefixed Measurement ID). While it is still the placeholder, `analytics.ts` sends nothing at
+ * all and says why in the console under `?analytics_debug=1`.
+ */
+export const GA_MEASUREMENT_ID_PLACEHOLDER = 'G-XXXXXXXXXX';
+export const GA_MEASUREMENT_ID: string = GA_MEASUREMENT_ID_PLACEHOLDER;
+
+/**
+ * Hostnames allowed to send measurements, so `localhost`, a `vite preview`, a fork's Pages build
+ * and a Cloudflare preview deploy cannot pollute the property that sponsor reports are drawn from.
+ * `?analytics_debug=1` overrides this for deliberate local verification.
+ */
+export const ANALYTICS_HOSTS: readonly string[] = ['img2threejs.io', 'www.img2threejs.io'];
+
 /**
  * Wraps every occurrence of the product name in the animated gradient span, so the brand reads the
  * same everywhere it appears — including inside strings that come from the registry (blurbs and
@@ -61,8 +83,21 @@ export const HEART = `&#9829;${TEXT_GLYPH}`;
 export const ARROW_OUT = `&#8599;${TEXT_GLYPH}`;
 
 export interface SponsorEntry {
+  /**
+   * Stable reporting key, and the reason it exists separately from `name`: sponsor reports are
+   * compared month over month, and a sponsor that rebrands must not become a second row that
+   * splits its own history in half. Never rename an id once a report has been sent to the sponsor.
+   */
+  id: string;
   name: string;
   url: string;
+  /**
+   * Extra hostnames belonging to this sponsor, beyond the one in `url`. Analytics attributes a
+   * click by hostname, so a link anywhere on the site — including a demo entry's `tripoUrl`
+   * provenance link, which points at an asset page rather than the marketing site — lands in the
+   * right sponsor's row without every page having to know who the sponsors are.
+   */
+  domains?: string[];
   /** The site renders dark-only (`color-scheme: dark`), so one light-on-dark mark is all it needs. */
   logo: string;
   /** What the sponsor sells, in their own terms. Sourced from their site, not written to flatter. */
@@ -83,6 +118,7 @@ export interface SponsorEntry {
  */
 export const SPONSORS: SponsorEntry[] = [
   {
+    id: 'atlas-cloud',
     name: 'Atlas Cloud',
     url: 'https://www.atlascloud.ai/console/coding-plan',
     logo: `${BASE}sponsors/atlas-cloud-logomark-white.svg`,
@@ -95,8 +131,13 @@ export const SPONSORS: SponsorEntry[] = [
     cta: 'Open the coding plan',
   },
   {
+    id: 'tripo',
     name: 'Tripo',
     url: 'https://www.tripo3d.ai/',
+    // `studio.tripo3d.ai` is where a demo's `tripoUrl` provenance link points; the resolver matches
+    // subdomains, so the marketing host alone would already cover it. Named anyway, because it is
+    // the one sponsor whose links appear outside the sponsor drawer.
+    domains: ['tripo3d.ai'],
     logo: `${BASE}sponsors/tripo-logomark-white.svg`,
     blurb:
       'Image- and text-to-3D at production quality: High Detail meshes up to 2M polygons, artist-' +
@@ -110,6 +151,7 @@ export const SPONSORS: SponsorEntry[] = [
     cta: 'Open Tripo Studio',
   },
   {
+    id: 'hyper3d',
     name: 'Hyper3D',
     url: 'https://hyper3d.ai/',
     logo: `${BASE}sponsors/hyper3d-logomark-white.png`,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1010,6 +1010,27 @@ body.intro-active { overflow: hidden; }
   color: var(--amber);
 }
 
+/**
+ * A drawer-to-drawer link inside a sentence. It has to be a <button>, not an <a>: the drawers are
+ * one overlay that swaps its own content, and an anchor would put a second history entry between
+ * the sponsor page and the privacy page it points at. Styled to read as the inline links beside it
+ * so the sentence does not visibly change register mid-clause.
+ */
+.dr-inline-link {
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: var(--amber);
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+  cursor: pointer;
+}
+
+.dr-inline-link:hover {
+  text-decoration-thickness: 2px;
+}
+
 .dr-actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Google Analytics 4, installed for one primary reason: **logo sponsors are owed evidence that their placement does something.** Everything else measured here answers "where do people actually spend their time on this site".

Full setup guide, event reference and the monthly sponsor-report recipe: [`docs/ANALYTICS.md`](docs/ANALYTICS.md).

## What this adds

- **`src/analytics.ts`** — every event the site can send is a named function. No page calls `gtag()` directly, so the event taxonomy is reviewable in one file and a report built in the GA4 UI cannot be quietly orphaned by a page renaming its event.
- **Sponsor reporting.** `sponsor_impression` fires from an IntersectionObserver when a card is genuinely on screen (25%, once per opening), `sponsor_click` on the outbound click. Both halves of the CTR are measured on the same terms. Attribution is by hostname against `SPONSORS`, so an exhibit's Tripo provenance link counts for Tripo without `pages/demo.ts` knowing what a sponsor is.
- **Engagement events** — exhibit views and load times, first orbit, explode, part select, animations, quality, search, FAQ opens, drawer opens, outbound clicks.
- **Manual `page_view`** with the hash route promoted out of the fragment (`/#/x/warrior` → `/x/warrior`). Without it GA4 strips the fragment and every route on the site reports as `/`.

## Privacy prose was rewritten, not left behind

The site claimed "no analytics, no cookies, no tracking" in five places. All five are corrected, and the privacy page now names the cookies, lists what is collected, states what sponsors are told, and carries an opt-out switch that takes effect without a reload. It also says plainly that the old claim was true and changed when the project took on logo sponsors.

The claim that the exhibits themselves make no network requests is unchanged and still enforced by `check-showcase-safety`.

## Sends nothing until it is configured

`GA_MEASUREMENT_ID` ships as the placeholder, so this merges inert: no script, no `dataLayer`, no third-party request. Analytics is also off for opted-out visitors, headless capture runs, `navigator.webdriver`, and any host outside `ANALYTICS_HOSTS`. `?analytics_debug=1` prints which of the five reasons applies.

## Before this measures anything — three GA UI steps that are not optional

Steps 3, 4 and 5 of the guide. Two of them are claims the privacy page already makes:

1. **Google Signals / ad personalisation / ads data sharing off** — the privacy page states this.
2. **Event data retention: 14 months** — the privacy page names the number; a new property defaults to less.
3. **Enhanced measurement → Page views → "Page changes based on browser history events": OFF.** The site is a hash router and calls `history.replaceState` on every exhibit swap. Left on, every page-view number in the property roughly doubles.

## Verification

Driven with CloakBrowser against a throwaway ID, reading `window.dataLayer` directly rather than trusting the console.

- All events fire with correct parameters, 0 page errors.
- `sponsor_click` from an exhibit's `tripoUrl` resolves to `sponsor_id: tripo`, `placement: demo_provenance` — hostname attribution works.
- 3 `sponsor_impression` on opening the sponsor drawer at 1400×950.
- Opt-out round trip, including opting back in after a reload without needing another one.
- Back/forward navigation sends exactly one `page_view` per step, and an in-place rail swap still sends its own.
- Placeholder ID: zero third-party requests, `dataLayer` absent, `gtag` undefined.
- `tsc --noEmit` clean · `npm run build` pass · `check-showcase-safety --base main` pass.
