### PR TITLE
fix(analytics): point at the dedicated img2threejs property, not the portfolio one

### DIFF
--- a/public/donate.html
+++ b/public/donate.html
@@ -265,7 +265,7 @@
     -->
     <script>
       (function () {
-        var GA_MEASUREMENT_ID = 'G-7GXMDHK2DE';
+        var GA_MEASUREMENT_ID = 'G-1EH8W9VJL4';
         var HOSTS = ['img2threejs.io', 'www.img2threejs.io'];
         var debug = /[?&]analytics_debug=1\b/.test(location.search);
 

--- a/src/site-data.ts
+++ b/src/site-data.ts
@@ -48,7 +48,7 @@ export const CURRENT_VERSION = 'v1.5.1';
  * all and says why in the console under `?analytics_debug=1`.
  */
 export const GA_MEASUREMENT_ID_PLACEHOLDER = 'G-XXXXXXXXXX';
-export const GA_MEASUREMENT_ID: string = 'G-7GXMDHK2DE';
+export const GA_MEASUREMENT_ID: string = 'G-1EH8W9VJL4';
 
 /**
  * Hostnames allowed to send measurements, so `localhost`, a `vite preview`, a fork's Pages build


### PR DESCRIPTION
`main` was merged in #48 with `G-7GXMDHK2DE`. That Measurement ID belongs to a stream that was
created **inside the `hoainho` property (439522747)**, alongside the live `hoainho.info` portfolio
stream — so every event from img2threejs.io currently lands in the portfolio property and mixes with
it, which is exactly what the dedicated property was created to prevent.

This swaps both copies of the ID to `G-1EH8W9VJL4`, the stream in the dedicated `img2threejs`
property (stream `15496976314`). Commit `3a57ab2` was pushed to this branch before #48 was merged
but did not make it into the merge.

Diff is two lines. The placeholder guard in `public/donate.html:277` is untouched.

Verified: `tsc --noEmit` clean · `npm run build` pass · `check-showcase-safety --base main` no
violations · ID present in `dist/donate.html` and `dist/assets/index-*.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)