### PR TITLE
fix(analytics): use a working measurement ID for the img2threejs property

### DIFF
--- a/public/donate.html
+++ b/public/donate.html
@@ -265,7 +265,7 @@
     -->
     <script>
       (function () {
-        var GA_MEASUREMENT_ID = 'G-1EH8W9VJL4';
+        var GA_MEASUREMENT_ID = 'G-4MSYRF7901';
         var HOSTS = ['img2threejs.io', 'www.img2threejs.io'];
         var debug = /[?&]analytics_debug=1\b/.test(location.search);
 

--- a/src/site-data.ts
+++ b/src/site-data.ts
@@ -48,7 +48,7 @@ export const CURRENT_VERSION = 'v1.5.1';
  * all and says why in the console under `?analytics_debug=1`.
  */
 export const GA_MEASUREMENT_ID_PLACEHOLDER = 'G-XXXXXXXXXX';
-export const GA_MEASUREMENT_ID: string = 'G-1EH8W9VJL4';
+export const GA_MEASUREMENT_ID: string = 'G-4MSYRF7901';
 
 /**
  * Hostnames allowed to send measurements, so `localhost`, a `vite preview`, a fork's Pages build


### PR DESCRIPTION
`G-1EH8W9VJL4` — the Measurement ID of stream `15496976314` — is served as **HTTP 404 text/html** by
`googletagmanager.com/gtag/js`. Verified from three independent clients (curl, a real Chromium, and
the author's Brave): a fabricated ID like `G-IEH8W9VJL4` gets a 200 with a generic 417KB container,
while this real ID deterministically 404s (5/5 retries). The 404 HTML is then correctly refused by
ORB when loaded as a script, so `gtag.js` never executes and no hit ever leaves the browser —
analytics has been collecting nothing since #49 deployed.

A replacement stream in the same property yields `G-4MSYRF7901`, which serves **200,
application/javascript, 506978 bytes** — larger than the generic container, i.e. a real provisioned
config. That isolates the fault to the one dead stream, not the property, so the property's custom
dimensions, metrics and key events are all unaffected.

Two lines. The placeholder guard at `public/donate.html:277` is deliberately untouched.

Site-side instrumentation was already verified against production and is not what was broken:
1 `page_view` on boot, 1 on browser Back (no double-count), 3 `sponsor_impression` on drawer open,
and `sponsor_click` carrying `sponsor_id: atlas-cloud` / `placement: sponsor_drawer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
