### PR TITLE
fix(awp-medusa-v2): label the exhibit img2threejs v1.4.4, not V2

### DIFF
--- a/src/demos/registry.ts
+++ b/src/demos/registry.ts
@@ -322,7 +322,7 @@ const authored: DemoEntry[] = [
     referenceImage: `${BASE}front-medusa.webp`,
     sourcePath: 'src/demos/awp-medusa-v2/createAwpMedusaModelV2.ts',
     sourceUrl: `${REPO}/src/demos/awp-medusa-v2/createAwpMedusaModelV2.ts`,
-    generatedWith: 'img2threejs V2 · custom AWP rifle adapter · blockout + projection + interactions complete',
+    generatedWith: 'img2threejs v1.4.4 · custom AWP rifle adapter · blockout + projection + interactions complete',
     author: 'kokorolx',
     authorUrl: 'https://github.com/kokorolx',
     status: 'final',


### PR DESCRIPTION
## What

The AWP | Medusa (Minimal Wear) · V2 rebuild was the only exhibit in the registry whose `generatedWith` recorded a demo-local tag (`V2`) instead of a pipeline version. Every other entry reads `img2threejs vX.Y.Z`. This pins it to **v1.4.4**, the version the Talon Doppler Ruby exhibit is labelled with.

```diff
-generatedWith: 'img2threejs V2 · custom AWP rifle adapter · blockout + projection + interactions complete',
+generatedWith: 'img2threejs v1.4.4 · custom AWP rifle adapter · blockout + projection + interactions complete',
```

## Scope

Label only. No geometry, camera, material, projection or interaction change — `awpMedusaV2Core.ts` and `object-sculpt-spec-v2.json` are untouched, so the pinned capture camera and the recorded silhouette IoUs (0.9205 front / 0.9171 back) still describe exactly the build they were measured on.

## Verification

- `npx tsc -p . --noEmit` clean.
- Rendered `#/demo/awp-medusa-v2` from this branch: `extractVersion()` now resolves the panel's version chip to `v1.4.4` (it previously resolved to `V2`, since the shared `VERSION_TAG` regex is case-insensitive), and the workbench Version spec reads the same.

## Follow-up, not included here

`src/site-data.ts` documents `VERSION_TAG` as "Case-insensitive because one entry records `V2`". This PR removes the last such entry, so that clause is now stale. Left untouched deliberately to keep the change to one line — happy to fold the comment update in if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)