### PR TITLE
fix(leesin): work when prewarm runs before build

### DIFF
--- a/src/demos/leesin/createLeesinModel.ts
+++ b/src/demos/leesin/createLeesinModel.ts
@@ -255,7 +255,21 @@ export function installMeasuredGeometry(root: THREE.Group, options: LeesinModelO
    * for looping clips, which is also what re-arms the one-shot bursts.
    */
   const vfx = createStrikeVfx(rig.nodes);
-  (root.parent ?? root).add(vfx.group);
+  /**
+   * Attached to the model's PARENT, and deferred if it does not have one yet.
+   *
+   * The parts inspector, the explode layout and the rig gate all walk `leesin-procedural` and assert
+   * 69 visible meshes; an effect mesh inside it is counted as a body part. On the demo page the root
+   * is already in the scene when this runs, but the workbench prewarms BEFORE it builds, so the root
+   * is still parentless here -- the effects landed inside the model and the exhibit reported 70 parts.
+   * Three dispatches `added` on the child, so waiting for it covers that order too.
+   */
+  const attachVfx = (): void => { (root.parent ?? root).add(vfx.group); };
+  if (root.parent) attachVfx();
+  else root.addEventListener('added', function onAdded() {
+    root.removeEventListener('added', onAdded);
+    attachVfx();
+  });
   let vfxClip: string | null = null;
   let vfxTime = 0;
   /**

--- a/src/demos/leesin/leesinDemo.ts
+++ b/src/demos/leesin/leesinDemo.ts
@@ -21,9 +21,22 @@ import type { LeesinModelOptions } from './createLeesinModel';
  * immediately and the copied meshes land on it when the payload has been decoded.
  */
 
-let pending: { root: THREE.Group; options: LeesinModelOptions } | null = null;
-let installed: Promise<void> | null = null;
+type MeasuredModule = typeof import('./createLeesinModel');
 
+let pending: { root: THREE.Group; options: LeesinModelOptions } | null = null;
+let prepared: MeasuredModule | null = null;
+let preparing: Promise<void> | null = null;
+
+/**
+ * Build and prewarm may arrive in EITHER order, and both have to work.
+ *
+ * The demo page builds first and prewarms after, so the payload lands on a root that is already in
+ * the scene. The workbench does the opposite: it awaits `prewarm` and only then calls `build`. The
+ * first version assumed the demo page's order and installed into `pending ?? a throwaway root` -- so
+ * on the workbench the geometry went into a root nobody kept, `build` handed back an empty group, and
+ * the exhibit read "PARTS 0" with no error anywhere. Ordering is now explicit in both directions:
+ * whichever runs second performs the install.
+ */
 export function createLeesinModel(options: LeesinModelOptions = {}): THREE.Group {
   const root = new THREE.Group();
   root.name = 'leesin-procedural';
@@ -31,15 +44,19 @@ export function createLeesinModel(options: LeesinModelOptions = {}): THREE.Group
   // than by a character compiler so the demo owns its own runtime contract.
   root.userData.sculptRuntime = {};
   pending = { root, options };
+  // Prewarm already finished: the payload is decoded and this root is the one that needs it.
+  if (prepared) prepared.installMeasuredGeometry(root, options);
   return root;
 }
 
 export function prewarmLeesin(): Promise<void> {
-  installed ??= (async () => {
+  preparing ??= (async () => {
     const measured = await import('./createLeesinModel');
     await measured.prepareLeesinMeasured();
-    const target = pending ?? { root: createLeesinModel(), options: {} };
-    measured.installMeasuredGeometry(target.root, target.options);
+    prepared = measured;
+    // Built already, or built while this was in flight: install into the live root. If nothing has
+    // been built yet, `createLeesinModel` installs as soon as it is.
+    if (pending) measured.installMeasuredGeometry(pending.root, pending.options);
   })();
-  return installed;
+  return preparing;
 }


### PR DESCRIPTION
The workbench awaits prewarm and only then builds, the opposite of the demo page, so the payload landed on a discarded root and the exhibit rendered an empty group reporting 0 parts with no error. The effects group now also waits for the model to have a parent before attaching, or it is counted as a body part.

<!--
  Adding a showcase demo? Fill the "Contributor" section only.
  Leave "Maintainer review" for whoever reviews the PR.
  See CONTRIBUTING.md for the full guide and the rules behind each checkbox.
-->

## Summary

- Demo id / title:
- One-line summary:
- Author (display name) / author URL:

## Contributor checklist

- [ ] Reference image rights: (own photo / public domain / licensed — name the source)
- [ ] Generated via the img2threejs skill (version: )
- [ ] `npm run build` passes locally
- [ ] Screenshot of the rendered demo attached below
- [ ] Only touched `src/demos/<id>/`, `public/references/<id>.<ext>`, and appended to `src/demos/registry.ts`
- [ ] New `registry.ts` entry has every `DemoEntry` field filled and `status: 'final'`

## Screenshot

<!-- paste here -->

---

## Maintainer review (do not fill as contributor)

- [ ] Visual fidelity acceptable against the reference image
- [ ] License/rights statement plausible; no PII or trademark-as-primary-subject issue
- [ ] `status: 'final'` (not left as `'placeholder'`)
- [ ] Bundle size delta looks sane
- [ ] `pr-safety-check` is green
