### PR TITLE
feat: add validated multi-model 3D asset exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "new-demo": "node scripts/new-showcase.mjs",
+    "qa:export:list": "node scripts/qa-export-matrix.mjs --list",
+    "qa:export:matrix": "node scripts/qa-export-matrix.mjs",
     "star-history": "node scripts/generate-star-history.mjs"
   },
   "dependencies": {

--- a/scripts/new-showcase.mjs
+++ b/scripts/new-showcase.mjs
@@ -39,6 +39,7 @@ function main() {
   const subjectClass = subjectClassArg === 'character' ? 'character' : 'object';
   const displayTitle = title || toPascalCase(id).replace(/([a-z])([A-Z])/g, '$1 $2');
   const pascalId = toPascalCase(id);
+  const updatedAt = new Date().toISOString().slice(0, 10);
   const factoryFnName = `create${pascalId}Model`;
   const demoDir = join(ROOT, 'src/demos', id);
   const factoryFile = join(demoDir, `${factoryFnName}.ts`);
@@ -68,12 +69,17 @@ function main() {
 // below keeps working, or update both if you rename it.
 export function ${factoryFnName}(): THREE.Group {
   const group = new THREE.Group();
+  group.name = '${id}';
   const mesh = new THREE.Mesh(
     new THREE.BoxGeometry(1, 1, 1),
     new THREE.MeshStandardMaterial({ color: 0x888888, roughness: 0.6 }),
   );
+  mesh.name = '${id}-mesh';
   mesh.castShadow = true;
   group.add(mesh);
+  // Full-assembly export is inherited automatically from the shared demo viewer. If this showcase
+  // contains multiple independent models, declare only those model roots here:
+  // group.userData.exportModels = [{ id: 'model-a', label: 'Model A', root: modelA }];
   return group;
 }
 `,
@@ -88,6 +94,7 @@ export function ${factoryFnName}(): THREE.Group {
 
   const entryBlock = `  {
     id: '${id}',
+    updatedAt: '${updatedAt}',
     title: '${displayTitle.replace(/'/g, "\\'")}',
     subjectClass: '${subjectClass}',
     blurb:
@@ -111,12 +118,12 @@ export function ${factoryFnName}(): THREE.Group {
 `;
 
   const withEntry = withImport.replace(
-    /(export const demos: DemoEntry\[\] = \[\n)/,
+    /(const authored: DemoEntry\[\] = \[\n)/,
     `$1${entryBlock}`,
   );
 
   if (withEntry === withImport) {
-    fail('could not find "export const demos: DemoEntry[] = [" in registry.ts — insert the entry manually.');
+    fail('could not find "const authored: DemoEntry[] = [" in registry.ts — insert the entry manually.');
   }
 
   writeFileSync(registryFile, withEntry);
@@ -130,10 +137,13 @@ Next steps:
   1. Replace the placeholder factory body with your generated code.
   2. Fill in every TODO in the new registry.ts entry (blurb, generatedWith, author, authorUrl).
   3. Add public/references/${id}.png (or .jpg/.jpeg/.webp, <= 800 KB).
-  4. npm run build && npm run preview   — check #/demo/${id}
-  5. node scripts/check-showcase-safety.mjs --base main
-  6. git add -A && git commit -m "Add ${id} showcase demo" && git push
-  7. gh pr create --fill   (or open https://github.com/hoainho/img2threejs-showcase/compare)
+  4. Open #/demo/${id} and verify the inherited six-format export panel.
+  5. If it contains multiple independent models, declare group.userData.exportModels roots.
+  6. npm run build && npm run preview
+  7. node scripts/qa-export-matrix.mjs --only=${id}
+  8. node scripts/check-showcase-safety.mjs --base main
+  9. git add -A && git commit -m "Add ${id} showcase demo" && git push
+ 10. gh pr create --fill   (or open https://github.com/hoainho/img2threejs-showcase/compare)
 `);
 }
 

--- a/scripts/qa-export-bundle.mjs
+++ b/scripts/qa-export-bundle.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const baseUrl = process.argv.find((value) => value.startsWith('--base-url='))?.split('=')[1]
+  ?? 'http://127.0.0.1:4173';
+const output = resolve(process.argv.find((value) => value.startsWith('--output='))?.split('=')[1]
+  ?? 'export-validation/2026-09-05-multi-model-zip');
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function loadPlaywright() {
+  try {
+    return await import('playwright');
+  } catch {
+    const globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf8' }).trim();
+    return import(pathToFileURL(join(globalRoot, 'playwright', 'index.mjs')).href);
+  }
+}
+
+async function waitForDownload(page, locator, destination) {
+  const pending = page.waitForEvent('download', { timeout: 15 * 60 * 1000 });
+  await locator.evaluate((element) => element.click());
+  const download = await pending;
+  await download.saveAs(destination);
+  await page.waitForFunction(() => (
+    document.querySelector('#demo-export-status')?.getAttribute('data-state') !== 'busy'
+  ), undefined, { timeout: 15 * 60 * 1000 });
+  const state = await page.locator('#demo-export-status').getAttribute('data-state');
+  const summary = await page.locator('#demo-export-summary').textContent();
+  assert(state === 'success' || state === 'warning', `Export UI ended in ${state}: ${summary}`);
+  return download.suggestedFilename();
+}
+
+async function inspectGlb(path) {
+  const bytes = await readFile(path);
+  assert(bytes.toString('ascii', 0, 4) === 'glTF', `${path} has no GLB magic`);
+  assert(bytes.readUInt32LE(4) === 2, `${path} is not GLB v2`);
+  assert(bytes.readUInt32LE(8) === bytes.byteLength, `${path} has an invalid declared length`);
+  const jsonLength = bytes.readUInt32LE(12);
+  const document = JSON.parse(bytes.subarray(20, 20 + jsonLength).toString('utf8').trimEnd());
+  const names = (document.nodes ?? []).map((node) => node.name).filter(Boolean);
+  return {
+    bytes: bytes.byteLength,
+    nodes: document.nodes?.length ?? 0,
+    meshes: document.meshes?.length ?? 0,
+    materials: document.materials?.length ?? 0,
+    textures: document.textures?.length ?? 0,
+    animations: document.animations?.length ?? 0,
+    names,
+  };
+}
+
+await mkdir(output, { recursive: true });
+const { chromium } = await loadPlaywright();
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({ acceptDownloads: true, viewport: { width: 1440, height: 960 } });
+const page = await context.newPage();
+page.setDefaultTimeout(15 * 60 * 1000);
+const pageErrors = [];
+page.on('pageerror', (error) => pageErrors.push(error.message));
+
+try {
+  await page.goto(`${baseUrl}/#/demo/starship-super-heavy`, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => typeof window.__IMG2THREEJS_EXPORT__ === 'function');
+  const exportTab = page.locator('#demo-tab-export');
+  if (await exportTab.count()) await exportTab.click();
+  await page.waitForFunction(() => document.querySelectorAll('#demo-export-scope-select option').length === 3);
+
+  const scopeOptions = await page.locator('#demo-export-scope-select option').evaluateAll((options) => (
+    options.map((option) => ({ value: option.value, label: option.textContent?.trim() }))
+  ));
+  assert(JSON.stringify(scopeOptions) === JSON.stringify([
+    { value: 'all', label: 'All models (2)' },
+    { value: 'super-heavy', label: 'Super Heavy booster' },
+    { value: 'starship', label: 'Starship upper stage' },
+  ]), `Unexpected export scopes: ${JSON.stringify(scopeOptions)}`);
+
+  const tooltipAudit = [];
+  const infoButtons = page.locator('[data-export-info]');
+  assert(await infoButtons.count() === 6, 'Expected one info control for each of six formats');
+  for (let index = 0; index < 6; index += 1) {
+    const button = infoButtons.nth(index);
+    await button.focus();
+    const tooltipId = await button.getAttribute('aria-describedby');
+    assert(tooltipId, `Info control ${index} has no described tooltip`);
+    const tooltip = page.locator(`#${tooltipId}`);
+    const text = (await tooltip.textContent())?.replace(/\s+/g, ' ').trim() ?? '';
+    const display = await tooltip.evaluate((element) => getComputedStyle(element).display);
+    assert(display !== 'none', `${tooltipId} is not visible on keyboard focus`);
+    assert(text.includes('Keeps') && text.includes('Limits'), `${tooltipId} omits portability detail`);
+    tooltipAudit.push({ id: tooltipId, text });
+  }
+
+  await infoButtons.first().click();
+  await page.locator('#demo-export').evaluate((element) => element.scrollIntoView({ block: 'start' }));
+  await page.screenshot({ path: join(output, 'desktop-export-ui.png') });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  if (await page.locator('#demo-panel').getAttribute('data-expanded') !== 'true') {
+    await page.locator('.demo-panel-bar').click();
+  }
+  await page.waitForFunction(() => document.querySelector('#demo-panel')?.getAttribute('data-expanded') === 'true');
+  if (await exportTab.count()) await exportTab.click();
+  if (await infoButtons.first().getAttribute('aria-expanded') !== 'true') await infoButtons.first().click();
+  const inspectorPanes = page.locator('.demo-inspector-panes');
+  if (await inspectorPanes.count()) {
+    await inspectorPanes.evaluate((element) => { element.scrollTop = 0; });
+  }
+  const mobileLayout = await page.evaluate(() => {
+    const viewportWidth = document.documentElement.clientWidth;
+    const nodes = [...document.querySelectorAll('.demo-export, .demo-export-format-row, .demo-export-tooltip')];
+    return {
+      viewportWidth,
+      documentWidth: document.documentElement.scrollWidth,
+      overflows: nodes.map((node) => {
+        const box = node.getBoundingClientRect();
+        return { className: node.className, left: box.left, right: box.right };
+      }).filter((box) => box.left < -1 || box.right > viewportWidth + 1),
+    };
+  });
+  assert(mobileLayout.documentWidth <= mobileLayout.viewportWidth + 1, 'Mobile page has horizontal overflow');
+  assert(mobileLayout.overflows.length === 0, `Mobile export controls overflow: ${JSON.stringify(mobileLayout.overflows)}`);
+  await page.screenshot({ path: join(output, 'mobile-export-ui.png') });
+
+  await page.setViewportSize({ width: 1440, height: 960 });
+  await page.locator('#demo-export-scope-select').selectOption('starship');
+  const starshipPath = join(output, 'starship-super-heavy--starship.glb');
+  const starshipFilename = await waitForDownload(
+    page,
+    page.locator('[data-export-format="glb"]'),
+    starshipPath,
+  );
+  assert(starshipFilename === 'starship-super-heavy--starship.glb', `Unexpected filename ${starshipFilename}`);
+
+  await page.locator('#demo-export-scope-select').selectOption('super-heavy');
+  const boosterPath = join(output, 'starship-super-heavy--super-heavy.glb');
+  const boosterFilename = await waitForDownload(
+    page,
+    page.locator('[data-export-format="glb"]'),
+    boosterPath,
+  );
+  assert(boosterFilename === 'starship-super-heavy--super-heavy.glb', `Unexpected filename ${boosterFilename}`);
+
+  await page.locator('#demo-export-scope-select').selectOption('starship');
+  const selectedZipPath = join(output, 'starship-super-heavy--starship-all-formats.zip');
+  const selectedZipFilename = await waitForDownload(page, page.locator('#demo-export-all'), selectedZipPath);
+  assert(
+    selectedZipFilename === 'starship-super-heavy--starship-all-formats.zip',
+    `Unexpected selected ZIP filename ${selectedZipFilename}`,
+  );
+  execFileSync('/usr/bin/unzip', ['-t', selectedZipPath], { stdio: 'pipe' });
+  const selectedEntries = execFileSync('/usr/bin/unzip', ['-Z1', selectedZipPath], { encoding: 'utf8' })
+    .trim().split('\n').filter(Boolean);
+  assert(selectedEntries.length === 7 && selectedEntries.includes('starship-super-heavy--starship.glb'),
+    `Selected ZIP entries are invalid: ${selectedEntries.join(', ')}`);
+  const selectedManifest = JSON.parse(execFileSync(
+    '/usr/bin/unzip',
+    ['-p', selectedZipPath, 'manifest.json'],
+    { encoding: 'utf8' },
+  ));
+  assert(selectedManifest.scope?.id === 'starship' && selectedManifest.scope?.kind === 'declared-model',
+    'Selected ZIP manifest scope is invalid');
+
+  await page.locator('#demo-export-scope-select').selectOption('all');
+  const zipPath = join(output, 'starship-super-heavy-all-formats.zip');
+  const zipFilename = await waitForDownload(page, page.locator('#demo-export-all'), zipPath);
+  assert(zipFilename === 'starship-super-heavy-all-formats.zip', `Unexpected ZIP filename ${zipFilename}`);
+
+  const entries = execFileSync('/usr/bin/unzip', ['-Z1', zipPath], { encoding: 'utf8' })
+    .trim().split('\n').filter(Boolean);
+  const expectedEntries = [
+    'starship-super-heavy.glb',
+    'starship-super-heavy.gltf',
+    'starship-super-heavy.obj',
+    'starship-super-heavy.stl',
+    'starship-super-heavy.ply',
+    'starship-super-heavy.usdz',
+    'manifest.json',
+  ];
+  assert(JSON.stringify(entries) === JSON.stringify(expectedEntries), `Unexpected ZIP entries: ${entries.join(', ')}`);
+  execFileSync('/usr/bin/unzip', ['-t', zipPath], { stdio: 'pipe' });
+  const extracted = join(output, 'unzipped');
+  await mkdir(extracted, { recursive: true });
+  execFileSync('/usr/bin/unzip', ['-oq', zipPath, '-d', extracted]);
+  const manifest = JSON.parse(await readFile(join(extracted, 'manifest.json'), 'utf8'));
+  assert(manifest.scope?.id === 'all' && manifest.scope?.kind === 'full-assembly', 'ZIP manifest scope is invalid');
+  assert(manifest.files?.length === 6, 'ZIP manifest does not describe all six formats');
+  for (const file of manifest.files) {
+    const info = await stat(join(extracted, file.filename));
+    assert(info.size === file.bytes, `${file.filename} size differs from its manifest`);
+  }
+
+  const starshipGlb = await inspectGlb(starshipPath);
+  const boosterGlb = await inspectGlb(boosterPath);
+  const assemblyGlb = await inspectGlb(join(extracted, 'starship-super-heavy.glb'));
+  assert(starshipGlb.names.includes('starship') && starshipGlb.names.includes('shipEngineBay'), 'Starship selection lost its expected hierarchy');
+  assert(!starshipGlb.names.includes('boosterHull'), 'Starship selection incorrectly contains Super Heavy geometry');
+  assert(boosterGlb.names.includes('superHeavy') && boosterGlb.names.includes('boosterHull'), 'Super Heavy selection lost its expected hierarchy');
+  assert(!boosterGlb.names.includes('shipEngineBay'), 'Super Heavy selection incorrectly contains Starship geometry');
+  assert(assemblyGlb.names.includes('boosterHull') && assemblyGlb.names.includes('shipEngineBay'), 'All-model GLB does not contain both declared models');
+
+  const result = {
+    generatedAt: new Date().toISOString(),
+    baseUrl,
+    scopeOptions,
+    tooltipAudit,
+    mobileLayout,
+    downloads: {
+      starship: starshipGlb,
+      superHeavy: boosterGlb,
+      assembly: assemblyGlb,
+      selectedZip: {
+        path: selectedZipPath,
+        bytes: (await stat(selectedZipPath)).size,
+        entries: selectedEntries,
+      },
+      zip: { path: zipPath, bytes: (await stat(zipPath)).size, entries },
+    },
+    manifest,
+    pageErrors,
+    success: pageErrors.length === 0,
+  };
+  await writeFile(join(output, 'qa-result.json'), `${JSON.stringify(result, null, 2)}\n`);
+  assert(result.success, `Browser page errors: ${pageErrors.join('; ')}`);
+  process.stdout.write(`PASS tooltips=${tooltipAudit.length} scopes=${scopeOptions.length} zipEntries=${entries.length}\n`);
+  process.stdout.write(`OUTPUT ${output}\n`);
+} finally {
+  await context.close();
+  await browser.close();
+}

--- a/scripts/qa-export-matrix.mjs
+++ b/scripts/qa-export-matrix.mjs
@@ -18,35 +18,63 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import { basename, join, resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import ts from 'typescript';
 
-const SHOWCASES = [
-  { id: 'raz', status: 'final' },
-  { id: 'mars-cat', status: 'final' },
-  { id: 'monster', status: 'placeholder' },
-  { id: 'leesin', status: 'final' },
-  { id: 'boxing-man', status: 'placeholder' },
-  { id: 'regret-warrior-reconstruction', status: 'placeholder' },
-  { id: 'warrior', status: 'placeholder' },
-  { id: 'starship-super-heavy', status: 'final' },
-  { id: 'girl-character', status: 'placeholder' },
-  { id: 'low-poly-humanoid', status: 'placeholder' },
-  { id: 'awp-medusa-v2', status: 'final' },
-  { id: 'electric-mouse-mascot', status: 'placeholder' },
-  { id: 'glock-ghost-protocol', status: 'final' },
-  { id: 'classic-fade', status: 'final' },
-  { id: 'bmx-endurance', status: 'final' },
-  { id: 'm9-doppler', status: 'final' },
-  { id: 'sony-wf1000xm3', status: 'final' },
-  { id: 'issaca-shotgun', status: 'final' },
-  { id: 'gerber-knife', status: 'final' },
-  { id: 'doraemon-house', status: 'final' },
-  { id: 'warhauler', status: 'final' },
-  { id: 'crown-chest', status: 'placeholder' },
-  { id: 'talon-doppler-ruby', status: 'final' },
-  { id: 'girl-character-3', status: 'final' },
-];
 const ALL_FORMATS = ['glb', 'gltf', 'obj', 'stl', 'ply', 'usdz'];
+
+/**
+ * Read the registry as TypeScript syntax instead of maintaining a second list by hand. A newly
+ * scaffolded DemoEntry is therefore part of the next export matrix automatically.
+ */
+async function loadRegisteredShowcases() {
+  const registryPath = fileURLToPath(new URL('../src/demos/registry.ts', import.meta.url));
+  const source = await readFile(registryPath, 'utf8');
+  const file = ts.createSourceFile(registryPath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  let authored;
+  const visit = (node) => {
+    if (
+      ts.isVariableDeclaration(node)
+      && ts.isIdentifier(node.name)
+      && node.name.text === 'authored'
+      && node.initializer
+      && ts.isArrayLiteralExpression(node.initializer)
+    ) {
+      authored = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  if (!authored) throw new Error(`Could not find the authored DemoEntry array in ${registryPath}`);
+
+  const stringProperty = (entry, name) => {
+    const property = entry.properties.find((candidate) => (
+      ts.isPropertyAssignment(candidate)
+      && ((ts.isIdentifier(candidate.name) && candidate.name.text === name)
+        || (ts.isStringLiteral(candidate.name) && candidate.name.text === name))
+    ));
+    return property && ts.isStringLiteralLike(property.initializer)
+      ? property.initializer.text
+      : undefined;
+  };
+  const showcases = authored.elements.map((element, index) => {
+    if (!ts.isObjectLiteralExpression(element)) {
+      throw new Error(`Registry entry ${index + 1} is not an object literal; export QA cannot discover it`);
+    }
+    const id = stringProperty(element, 'id');
+    const status = stringProperty(element, 'status');
+    if (!id || !['placeholder', 'final'].includes(status)) {
+      throw new Error(`Registry entry ${index + 1} needs literal id and status fields for export QA`);
+    }
+    return { id, status };
+  });
+  const duplicate = showcases.find(({ id }, index) => showcases.findIndex((entry) => entry.id === id) !== index);
+  if (duplicate) throw new Error(`Duplicate showcase id in registry: ${duplicate.id}`);
+  return showcases;
+}
+
+const SHOWCASES = await loadRegisteredShowcases();
 
 function option(name, fallback) {
   const prefix = `--${name}=`;
@@ -58,6 +86,9 @@ const outputRoot = resolve(option('output', 'export-validation/latest'));
 const requestedIds = option('only', '').split(',').filter(Boolean);
 const formats = option('formats', ALL_FORMATS.join(',')).split(',').filter(Boolean);
 const resume = process.argv.includes('--resume');
+const listOnly = process.argv.includes('--list');
+const unknownIds = requestedIds.filter((id) => !SHOWCASES.some((showcase) => showcase.id === id));
+if (unknownIds.length) throw new Error(`Unknown showcase ids: ${unknownIds.join(', ')}`);
 const selected = requestedIds.length
   ? SHOWCASES.filter(({ id }) => requestedIds.includes(id))
   : SHOWCASES;
@@ -65,6 +96,10 @@ const selected = requestedIds.length
 if (!selected.length) throw new Error('No matching showcase ids');
 if (formats.some((format) => !ALL_FORMATS.includes(format))) {
   throw new Error(`Unknown format in ${formats.join(', ')}`);
+}
+if (listOnly) {
+  process.stdout.write(`${selected.map(({ id, status }) => `${id}\t${status}`).join('\n')}\n`);
+  process.exit(0);
 }
 
 async function loadPlaywright() {

--- a/scripts/qa-export-matrix.mjs
+++ b/scripts/qa-export-matrix.mjs
@@ -1,0 +1,490 @@
+#!/usr/bin/env node
+
+/**
+ * Production-browser export evidence runner.
+ *
+ * This deliberately clicks the same buttons a visitor clicks. Every resulting
+ * browser download is retained, hashed, structurally inspected, and recorded
+ * in manifest.json so export claims can be audited outside the app.
+ */
+import { createHash } from 'node:crypto';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createReadStream } from 'node:fs';
+import {
+  mkdir,
+  open,
+  readFile,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import { basename, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SHOWCASES = [
+  { id: 'raz', status: 'final' },
+  { id: 'mars-cat', status: 'final' },
+  { id: 'monster', status: 'placeholder' },
+  { id: 'leesin', status: 'final' },
+  { id: 'boxing-man', status: 'placeholder' },
+  { id: 'regret-warrior-reconstruction', status: 'placeholder' },
+  { id: 'warrior', status: 'placeholder' },
+  { id: 'starship-super-heavy', status: 'final' },
+  { id: 'girl-character', status: 'placeholder' },
+  { id: 'low-poly-humanoid', status: 'placeholder' },
+  { id: 'awp-medusa-v2', status: 'final' },
+  { id: 'electric-mouse-mascot', status: 'placeholder' },
+  { id: 'glock-ghost-protocol', status: 'final' },
+  { id: 'classic-fade', status: 'final' },
+  { id: 'bmx-endurance', status: 'final' },
+  { id: 'm9-doppler', status: 'final' },
+  { id: 'sony-wf1000xm3', status: 'final' },
+  { id: 'issaca-shotgun', status: 'final' },
+  { id: 'gerber-knife', status: 'final' },
+  { id: 'doraemon-house', status: 'final' },
+  { id: 'warhauler', status: 'final' },
+  { id: 'crown-chest', status: 'placeholder' },
+  { id: 'talon-doppler-ruby', status: 'final' },
+  { id: 'girl-character-3', status: 'final' },
+];
+const ALL_FORMATS = ['glb', 'gltf', 'obj', 'stl', 'ply', 'usdz'];
+
+function option(name, fallback) {
+  const prefix = `--${name}=`;
+  return process.argv.find((argument) => argument.startsWith(prefix))?.slice(prefix.length) ?? fallback;
+}
+
+const baseUrl = option('base-url', 'http://127.0.0.1:4173');
+const outputRoot = resolve(option('output', 'export-validation/latest'));
+const requestedIds = option('only', '').split(',').filter(Boolean);
+const formats = option('formats', ALL_FORMATS.join(',')).split(',').filter(Boolean);
+const resume = process.argv.includes('--resume');
+const selected = requestedIds.length
+  ? SHOWCASES.filter(({ id }) => requestedIds.includes(id))
+  : SHOWCASES;
+
+if (!selected.length) throw new Error('No matching showcase ids');
+if (formats.some((format) => !ALL_FORMATS.includes(format))) {
+  throw new Error(`Unknown format in ${formats.join(', ')}`);
+}
+
+async function loadPlaywright() {
+  try {
+    return await import('playwright');
+  } catch {
+    const globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf8' }).trim();
+    return import(pathToFileURL(join(globalRoot, 'playwright', 'index.mjs')).href);
+  }
+}
+
+async function sha256(path) {
+  const digest = createHash('sha256');
+  for await (const chunk of createReadStream(path)) digest.update(chunk);
+  return digest.digest('hex');
+}
+
+async function readPrefix(path, length = 64 * 1024) {
+  const file = await open(path, 'r');
+  try {
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await file.read(buffer, 0, length, 0);
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    await file.close();
+  }
+}
+
+async function containsObjRecords(path) {
+  let carry = '';
+  let hasVertices = false;
+  let hasNormals = false;
+  let hasFaces = false;
+  let hasUvs = false;
+  let objects = 0;
+  for await (const chunk of createReadStream(path, { encoding: 'utf8' })) {
+    const text = carry + chunk;
+    hasVertices ||= /(^|\n)v /.test(text);
+    hasNormals ||= /(^|\n)vn /.test(text);
+    hasFaces ||= /(^|\n)f /.test(text);
+    hasUvs ||= /(^|\n)vt /.test(text);
+    objects += (text.match(/(^|\n)o /g) ?? []).length;
+    carry = text.slice(-4);
+  }
+  return { hasVertices, hasNormals, hasFaces, hasUvs, objects };
+}
+
+async function readGlbDocument(path) {
+  const file = await open(path, 'r');
+  try {
+    const header = Buffer.alloc(20);
+    const headerRead = await file.read(header, 0, header.length, 0);
+    if (headerRead.bytesRead !== header.length || header.toString('ascii', 0, 4) !== 'glTF') {
+      throw new Error('GLB JSON inspection failed: invalid header');
+    }
+    const jsonLength = header.readUInt32LE(12);
+    if (header.readUInt32LE(16) !== 0x4e4f534a) {
+      throw new Error('GLB JSON inspection failed: first chunk is not JSON');
+    }
+    const json = Buffer.alloc(jsonLength);
+    const jsonRead = await file.read(json, 0, json.length, 20);
+    if (jsonRead.bytesRead !== json.length) throw new Error('GLB JSON inspection failed: truncated JSON chunk');
+    return JSON.parse(json.toString('utf8').trimEnd());
+  } finally {
+    await file.close();
+  }
+}
+
+function materialTextureIndices(materials = []) {
+  const indices = [];
+  const visit = (value, key = '') => {
+    if (!value || typeof value !== 'object') return;
+    if (key.endsWith('Texture') && Number.isInteger(value.index)) {
+      indices.push(value.index);
+      return;
+    }
+    for (const [childKey, child] of Object.entries(value)) visit(child, childKey);
+  };
+  for (const material of materials) visit(material);
+  return indices;
+}
+
+function inspectGltfDocument(document, expected) {
+  if (document.asset?.version !== '2.0') throw new Error('glTF asset.version is not 2.0');
+  const invalidAccessor = (document.accessors ?? []).findIndex((accessor) => (
+    [...(accessor.min ?? []), ...(accessor.max ?? [])]
+      .some((value) => typeof value !== 'number' || !Number.isFinite(value))
+  ));
+  if (invalidAccessor >= 0) {
+    throw new Error(`glTF accessor ${invalidAccessor} contains non-finite bounds`);
+  }
+  const primitives = (document.meshes ?? []).flatMap((mesh) => mesh.primitives ?? []);
+  const primitivesForNode = (node) => (
+    node.mesh === undefined ? [] : document.meshes?.[node.mesh]?.primitives ?? []
+  );
+  const textureIndices = materialTextureIndices(document.materials);
+  const result = {
+    gltfVersion: document.asset.version,
+    scenes: document.scenes?.length ?? 0,
+    nodes: document.nodes?.length ?? 0,
+    meshNodes: (document.nodes ?? []).filter((node) => node.mesh !== undefined).length,
+    namedMeshNodes: (document.nodes ?? []).filter((node) => node.mesh !== undefined && node.name).length,
+    meshes: document.meshes?.length ?? 0,
+    primitives: primitives.length,
+    materials: document.materials?.length ?? 0,
+    textures: document.textures?.length ?? 0,
+    images: document.images?.length ?? 0,
+    textureBindings: textureIndices.length,
+    uvPrimitives: primitives.filter((primitive) => primitive.attributes?.TEXCOORD_0 !== undefined).length,
+    colouredPrimitives: primitives.filter((primitive) => primitive.attributes?.COLOR_0 !== undefined).length,
+    skinnedPrimitives: primitives.filter((primitive) => (
+      primitive.attributes?.JOINTS_0 !== undefined && primitive.attributes?.WEIGHTS_0 !== undefined
+    )).length,
+    uvMeshNodes: (document.nodes ?? []).filter((node) => primitivesForNode(node).some(
+      (primitive) => primitive.attributes?.TEXCOORD_0 !== undefined,
+    )).length,
+    colouredMeshNodes: (document.nodes ?? []).filter((node) => primitivesForNode(node).some(
+      (primitive) => primitive.attributes?.COLOR_0 !== undefined,
+    )).length,
+    weightedMeshNodes: (document.nodes ?? []).filter((node) => (
+      node.skin !== undefined && primitivesForNode(node).some((primitive) => (
+        primitive.attributes?.JOINTS_0 !== undefined && primitive.attributes?.WEIGHTS_0 !== undefined
+      ))
+    )).length,
+    skins: document.skins?.length ?? 0,
+    joints: (document.skins ?? []).reduce((sum, skin) => sum + (skin.joints?.length ?? 0), 0),
+    animations: document.animations?.length ?? 0,
+    animationChannels: (document.animations ?? []).reduce(
+      (sum, animation) => sum + (animation.channels?.length ?? 0), 0,
+    ),
+  };
+  if (!result.scenes || !result.nodes || !result.meshes || !result.primitives) {
+    throw new Error(`glTF scene structure is incomplete: ${JSON.stringify(result)}`);
+  }
+  if (textureIndices.some((index) => index < 0 || index >= result.textures)) {
+    throw new Error('glTF material references an invalid texture index');
+  }
+  if ((document.textures ?? []).some((texture) => (
+    !Number.isInteger(texture.source) || texture.source < 0 || texture.source >= result.images
+  ))) {
+    throw new Error('glTF texture references an invalid image index');
+  }
+  if (expected) {
+    const requirements = [
+      ['meshNodes', expected.meshCount],
+      ['namedMeshNodes', expected.namedPartCount],
+      ['materials', expected.portableMaterialCount],
+      ['textureBindings', expected.textureBindingCount],
+      ['uvMeshNodes', expected.uvMeshCount],
+      ['colouredMeshNodes', expected.vertexColourMeshCount],
+      ['weightedMeshNodes', expected.skinnedMeshCount],
+      ['skins', expected.skinnedMeshCount],
+      ['animations', expected.animationCount],
+    ];
+    for (const [field, minimum] of requirements) {
+      if (result[field] < minimum) {
+        throw new Error(`glTF parity failed: ${field} expected >= ${minimum}, found ${result[field]}`);
+      }
+    }
+    if (expected.portableTextureCount > 0 && (!result.textures || !result.images)) {
+      throw new Error('glTF parity failed: source textures have no embedded image payload');
+    }
+  }
+  return result;
+}
+
+async function inspectArtifact(path, format, expected) {
+  const info = await stat(path);
+  const prefix = await readPrefix(path);
+  const evidence = { bytes: info.size, sha256: await sha256(path) };
+  if (format === 'glb') {
+    if (prefix.toString('ascii', 0, 4) !== 'glTF') throw new Error('GLB magic is missing');
+    const version = prefix.readUInt32LE(4);
+    const declaredBytes = prefix.readUInt32LE(8);
+    if (version !== 2 || declaredBytes !== info.size) {
+      throw new Error(`GLB header mismatch: version=${version}, declared=${declaredBytes}, actual=${info.size}`);
+    }
+    const document = await readGlbDocument(path);
+    return { ...evidence, declaredBytes, ...inspectGltfDocument(document, expected) };
+  }
+  if (format === 'gltf') {
+    const document = JSON.parse(await readFile(path, 'utf8'));
+    return { ...evidence, ...inspectGltfDocument(document, expected) };
+  }
+  if (format === 'obj') {
+    const records = await containsObjRecords(path);
+    if (!records.hasVertices || !records.hasNormals || !records.hasFaces) {
+      throw new Error(`OBJ records are incomplete: ${JSON.stringify(records)}`);
+    }
+    if (expected?.namedPartCount > records.objects) {
+      throw new Error(`OBJ part parity failed: expected ${expected.namedPartCount}, found ${records.objects}`);
+    }
+    if (expected?.uvMeshCount > 0 && !records.hasUvs) {
+      throw new Error('OBJ UV parity failed: source UVs are missing');
+    }
+    return { ...evidence, ...records };
+  }
+  if (format === 'stl') {
+    if (info.size < 84) throw new Error('STL is shorter than its binary header');
+    const triangles = prefix.readUInt32LE(80);
+    if (84 + triangles * 50 !== info.size) throw new Error('STL triangle count does not match byte length');
+    return { ...evidence, triangles };
+  }
+  if (format === 'ply') {
+    const headerEnd = prefix.indexOf('end_header\n');
+    if (prefix.toString('ascii', 0, 3) !== 'ply' || headerEnd < 0) throw new Error('PLY header is invalid');
+    const header = prefix.toString('ascii', 0, headerEnd + 11);
+    if (!header.includes('format binary_little_endian 1.0')) throw new Error('PLY is not binary little-endian');
+    const vertices = Number(header.match(/element vertex (\d+)/)?.[1] ?? -1);
+    const faces = Number(header.match(/element face (\d+)/)?.[1] ?? -1);
+    if (vertices < 0 || faces < 0) throw new Error('PLY vertex/face counts are missing');
+    const hasVertexColors = header.includes('property uchar red');
+    const hasUvs = header.includes('property float s');
+    if (expected?.vertexColourMeshCount > 0 && !hasVertexColors) {
+      throw new Error('PLY colour parity failed: source vertex colours are missing');
+    }
+    if (expected?.uvMeshCount > 0 && !hasUvs) {
+      throw new Error('PLY UV parity failed: source UVs are missing');
+    }
+    return { ...evidence, vertices, faces, hasVertexColors, hasUvs };
+  }
+  if (prefix.readUInt32LE(0) !== 0x04034b50) throw new Error('USDZ ZIP magic is missing');
+  const usdcheck = spawnSync('/usr/bin/usdchecker', [path], { encoding: 'utf8', timeout: 5 * 60 * 1000 });
+  const checkerText = `${usdcheck.stdout ?? ''}\n${usdcheck.stderr ?? ''}`;
+  if (usdcheck.status !== 0 || !checkerText.includes('Success!')) {
+    throw new Error(`usdchecker failed (${usdcheck.status}): ${checkerText.slice(-1000)}`);
+  }
+  return { ...evidence, usdchecker: 'Success!' };
+}
+
+async function waitForDownloadOrError(page, button) {
+  let downloaded;
+  let onDownload;
+  const downloadPromise = new Promise((resolveDownload) => {
+    onDownload = (download) => resolveDownload(download);
+    page.once('download', onDownload);
+  }).then((download) => {
+    downloaded = download;
+    return download;
+  });
+  // Schedule the real DOM click after this CDP evaluation returns. Some animation-heavy exports
+  // enter a long microtask before Playwright receives the acknowledgement for locator.click(),
+  // incorrectly turning successful work into a 15-minute actionability timeout.
+  await button.evaluate((element) => {
+    window.setTimeout(() => element.click(), 0);
+  });
+  const deadline = Date.now() + 15 * 60 * 1000;
+  while (!downloaded && Date.now() < deadline) {
+    await Promise.race([
+      downloadPromise,
+      new Promise((resolveWait) => setTimeout(resolveWait, 250)),
+    ]);
+    if (downloaded) return downloaded;
+    const ui = await page.evaluate(() => ({
+      state: document.querySelector('#demo-export-status')?.getAttribute('data-state') ?? '',
+      status: document.querySelector('#demo-export-status')?.textContent?.trim() ?? '',
+      summary: document.querySelector('#demo-export-summary')?.textContent?.trim() ?? '',
+    }));
+    if (ui.state === 'error') {
+      page.off('download', onDownload);
+      throw new Error(`${ui.status}: ${ui.summary}`);
+    }
+  }
+  if (downloaded) return downloaded;
+  page.off('download', onDownload);
+  throw new Error('Timed out after 15 minutes waiting for a validated browser download');
+}
+
+await mkdir(outputRoot, { recursive: true });
+const manifestPath = join(outputRoot, 'manifest.json');
+let manifest;
+if (resume) {
+  try {
+    manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  } catch {
+    // A missing/incomplete prior manifest simply starts a fresh run.
+  }
+}
+manifest ??= {
+  generatedAt: new Date().toISOString(),
+  baseUrl,
+  outputRoot,
+  requestedShowcases: selected.map(({ id }) => id),
+  requestedFormats: formats,
+  results: [],
+};
+manifest.completedAt = undefined;
+manifest.success = undefined;
+const recalculateTotals = () => {
+  manifest.totals = {
+    requested: selected.length * formats.length,
+    passed: manifest.results.filter((result) => result.status === 'passed').length,
+    failed: manifest.results.filter((result) => result.status === 'failed').length,
+  };
+};
+recalculateTotals();
+const persist = () => writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+await persist();
+
+const { chromium } = await loadPlaywright();
+for (const showcase of selected) {
+    const completed = formats.map((format) => manifest.results.find((result) => (
+      result.showcase === showcase.id && result.format === format && result.status === 'passed'
+    )));
+    if (completed.every(Boolean)) {
+      for (const prior of completed) {
+        const priorInfo = await stat(prior.path);
+        if (priorInfo.size !== prior.file?.bytes) {
+          throw new Error(`Saved evidence changed for ${showcase.id}.${prior.format}`);
+        }
+      }
+      process.stdout.write(`SHOWCASE ${showcase.id} (${showcase.status}) — SKIP complete prior PASS\n`);
+      continue;
+    }
+    // A fresh browser process is intentional: very large Blob downloads and WebGL resources can
+    // survive context disposal in Chromium and make later showcases fail from accumulated memory.
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({ acceptDownloads: true });
+    const page = await context.newPage();
+    page.setDefaultTimeout(15 * 60 * 1000);
+    const pageErrors = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+    process.stdout.write(`SHOWCASE ${showcase.id} (${showcase.status})\n`);
+    try {
+      await page.goto(`${baseUrl}/#/demo/${showcase.id}`, { waitUntil: 'domcontentloaded', timeout: 15 * 60 * 1000 });
+      await page.waitForFunction(() => typeof window.__IMG2THREEJS_EXPORT__ === 'function');
+      for (const format of formats) {
+        const previous = manifest.results.find((result) => (
+          result.showcase === showcase.id && result.format === format && result.status === 'passed'
+        ));
+        if (previous) {
+          const previousInfo = await stat(previous.path);
+          if (previousInfo.size !== previous.file?.bytes) {
+            throw new Error(`Saved evidence changed for ${showcase.id}.${format}`);
+          }
+          process.stdout.write(`  SKIP ${format.toUpperCase()} prior PASS ${previousInfo.size} bytes\n`);
+          continue;
+        }
+        manifest.results = manifest.results.filter((result) => !(
+          result.showcase === showcase.id && result.format === format
+        ));
+        recalculateTotals();
+        const startedAt = Date.now();
+        const destinationDirectory = join(outputRoot, showcase.id);
+        const destination = join(destinationDirectory, `${showcase.id}.${format}`);
+        const result = {
+          showcase: showcase.id,
+          showcaseStatus: showcase.status,
+          format,
+          path: destination,
+          status: 'failed',
+        };
+        try {
+          await mkdir(destinationDirectory, { recursive: true });
+          const button = page.locator(`[data-export-format="${format}"]`);
+          const download = await waitForDownloadOrError(page, button);
+          await download.saveAs(destination);
+          await page.waitForFunction(() => {
+            const node = document.querySelector('#demo-export-status');
+            return node?.getAttribute('data-state') !== 'busy';
+          });
+          const ui = await page.evaluate(() => ({
+            state: document.querySelector('#demo-export-status')?.getAttribute('data-state') ?? '',
+            status: document.querySelector('#demo-export-status')?.textContent?.trim() ?? '',
+            summary: document.querySelector('#demo-export-summary')?.textContent?.trim() ?? '',
+            warnings: [...document.querySelectorAll('#demo-export-warnings li')]
+              .map((node) => node.textContent?.trim() ?? '')
+              .filter(Boolean),
+            report: window.__IMG2THREEJS_LAST_EXPORT_REPORT__ ?? null,
+          }));
+          if (!['success', 'warning'].includes(ui.state)) {
+            throw new Error(`UI validation state is ${ui.state || 'empty'}: ${ui.status}`);
+          }
+          result.durationMs = Date.now() - startedAt;
+          result.suggestedFilename = download.suggestedFilename();
+          result.ui = ui;
+          result.file = await inspectArtifact(destination, format, ui.report);
+          result.pageErrors = [...pageErrors];
+          result.status = 'passed';
+          process.stdout.write(`  PASS ${format.toUpperCase()} ${result.file.bytes} bytes ${result.durationMs} ms\n`);
+        } catch (error) {
+          result.durationMs = Date.now() - startedAt;
+          result.error = error instanceof Error ? error.stack ?? error.message : String(error);
+          result.pageErrors = [...pageErrors];
+          process.stdout.write(`  FAIL ${format.toUpperCase()} ${result.error.split('\n')[0]}\n`);
+        }
+        manifest.results.push(result);
+        recalculateTotals();
+        await persist();
+      }
+    } catch (error) {
+      for (const format of formats) {
+        const alreadyPassed = manifest.results.some((result) => (
+          result.showcase === showcase.id && result.format === format && result.status === 'passed'
+        ));
+        if (alreadyPassed) continue;
+        manifest.results = manifest.results.filter((result) => !(
+          result.showcase === showcase.id && result.format === format
+        ));
+        manifest.results.push({
+          showcase: showcase.id,
+          showcaseStatus: showcase.status,
+          format,
+          status: 'failed',
+          error: error instanceof Error ? error.stack ?? error.message : String(error),
+          pageErrors,
+        });
+      }
+      recalculateTotals();
+      await persist();
+      process.stdout.write(`  PAGE FAIL ${error instanceof Error ? error.message : String(error)}\n`);
+    } finally {
+      await context.close();
+      await browser.close();
+    }
+  }
+
+manifest.completedAt = new Date().toISOString();
+manifest.success = manifest.totals.failed === 0 && manifest.totals.passed === manifest.totals.requested;
+await persist();
+process.stdout.write(`MANIFEST ${manifestPath}\n`);
+process.stdout.write(`RESULT ${manifest.totals.passed}/${manifest.totals.requested} passed\n`);
+process.exitCode = manifest.success ? 0 : 1;

--- a/scripts/qa-sony-export-selection.mjs
+++ b/scripts/qa-sony-export-selection.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const baseUrl = process.argv.find((value) => value.startsWith('--base-url='))?.split('=')[1]
+  ?? 'http://127.0.0.1:4173';
+const output = resolve(process.argv.find((value) => value.startsWith('--output='))?.split('=')[1]
+  ?? 'export-validation/2026-09-05-multi-model-zip/sony-selections');
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function loadPlaywright() {
+  try {
+    return await import('playwright');
+  } catch {
+    const globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf8' }).trim();
+    return import(pathToFileURL(join(globalRoot, 'playwright', 'index.mjs')).href);
+  }
+}
+
+function glbNames(bytes) {
+  assert(bytes.toString('ascii', 0, 4) === 'glTF', 'Downloaded selection is not a GLB');
+  const jsonLength = bytes.readUInt32LE(12);
+  const document = JSON.parse(bytes.subarray(20, 20 + jsonLength).toString('utf8').trimEnd());
+  return {
+    nodes: document.nodes?.length ?? 0,
+    meshes: document.meshes?.length ?? 0,
+    materials: document.materials?.length ?? 0,
+    textures: document.textures?.length ?? 0,
+    names: (document.nodes ?? []).map((node) => node.name).filter(Boolean),
+  };
+}
+
+await mkdir(output, { recursive: true });
+const { chromium } = await loadPlaywright();
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({ acceptDownloads: true });
+const page = await context.newPage();
+const errors = [];
+page.on('pageerror', (error) => errors.push(error.message));
+
+try {
+  await page.goto(`${baseUrl}/#/demo/sony-wf1000xm3`, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => typeof window.__IMG2THREEJS_EXPORT__ === 'function');
+  const exportTab = page.locator('#demo-tab-export');
+  if (await exportTab.count()) await exportTab.click();
+  await page.waitForFunction(() => document.querySelectorAll('#demo-export-scope-select option').length === 4);
+  const scopes = await page.locator('#demo-export-scope-select option').evaluateAll((options) => (
+    options.map((option) => ({ id: option.value, label: option.textContent?.trim() }))
+  ));
+  assert(JSON.stringify(scopes) === JSON.stringify([
+    { id: 'all', label: 'All models (3)' },
+    { id: 'charging-case', label: 'Charging case' },
+    { id: 'left-earbud', label: 'Left earbud' },
+    { id: 'right-earbud', label: 'Right earbud' },
+  ]), `Unexpected Sony scopes: ${JSON.stringify(scopes)}`);
+
+  const selections = {};
+  for (const scope of scopes.slice(1)) {
+    await page.locator('#demo-export-scope-select').selectOption(scope.id);
+    const pending = page.waitForEvent('download', { timeout: 5 * 60 * 1000 });
+    await page.locator('[data-export-format="glb"]').evaluate((button) => button.click());
+    const download = await pending;
+    const path = join(output, `sony-wf1000xm3--${scope.id}.glb`);
+    await download.saveAs(path);
+    await page.waitForFunction(() => (
+      document.querySelector('#demo-export-status')?.getAttribute('data-state') !== 'busy'
+    ));
+    const bytes = await readFile(path);
+    selections[scope.id] = { path, bytes: bytes.byteLength, ...glbNames(bytes) };
+  }
+
+  assert(selections['charging-case'].names.includes('chargingCase'), 'Charging case hierarchy is missing');
+  assert(!selections['charging-case'].names.includes('leftEarbud'), 'Charging case includes an earbud');
+  assert(selections['left-earbud'].names.includes('leftEarbud'), 'Left earbud hierarchy is missing');
+  assert(!selections['left-earbud'].names.includes('rightEarbud'), 'Left selection includes the right earbud');
+  assert(selections['right-earbud'].names.includes('rightEarbud'), 'Right earbud hierarchy is missing');
+  assert(!selections['right-earbud'].names.includes('leftEarbud'), 'Right selection includes the left earbud');
+  assert(errors.length === 0, `Browser errors: ${errors.join('; ')}`);
+  await writeFile(join(output, 'qa-result.json'), `${JSON.stringify({ scopes, selections, errors }, null, 2)}\n`);
+  process.stdout.write(`PASS scopes=${scopes.length} selections=${Object.keys(selections).length}\n`);
+  process.stdout.write(`OUTPUT ${output}\n`);
+} finally {
+  await context.close();
+  await browser.close();
+}

--- a/scripts/validate-export-blender.py
+++ b/scripts/validate-export-blender.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Import an exported GLB/glTF/OBJ/STL/PLY with Blender and verify DCC data."""
+
+import argparse
+import bpy
+import json
+from pathlib import Path
+import sys
+
+
+def arguments() -> argparse.Namespace:
+    argv = sys.argv[sys.argv.index("--") + 1 :] if "--" in sys.argv else []
+    parser = argparse.ArgumentParser()
+    parser.add_argument("asset")
+    parser.add_argument("--min-meshes", type=int, default=1)
+    parser.add_argument("--min-bones", type=int, default=0)
+    parser.add_argument("--min-weighted-meshes", type=int, default=0)
+    parser.add_argument("--min-actions", type=int, default=0)
+    parser.add_argument("--min-images", type=int, default=0)
+    parser.add_argument("--min-textured-materials", type=int, default=0)
+    parser.add_argument("--min-color-attributes", type=int, default=0)
+    parser.add_argument("--summary-only", action="store_true")
+    return parser.parse_args(argv)
+
+
+args = arguments()
+bpy.ops.wm.read_factory_settings(use_empty=True)
+extension = Path(args.asset).suffix.lower()
+importers = {
+    ".glb": bpy.ops.import_scene.gltf,
+    ".gltf": bpy.ops.import_scene.gltf,
+    ".obj": bpy.ops.wm.obj_import,
+    ".stl": bpy.ops.wm.stl_import,
+    ".ply": bpy.ops.wm.ply_import,
+}
+if extension not in importers:
+    raise SystemExit(f"unsupported Blender validation format: {extension}")
+import_result = importers[extension](filepath=args.asset)
+
+mesh_objects = [obj for obj in bpy.context.scene.objects if obj.type == "MESH"]
+armatures = [obj for obj in bpy.context.scene.objects if obj.type == "ARMATURE"]
+materials = list(bpy.data.materials)
+images = [image for image in bpy.data.images if image.source != "VIEWER"]
+actions = list(bpy.data.actions)
+textured_materials = sum(
+    1
+    for material in materials
+    if material.node_tree
+    and any(
+        node.type == "TEX_IMAGE" and getattr(node, "image", None) is not None
+        for node in material.node_tree.nodes
+    )
+)
+weighted_meshes = sum(1 for obj in mesh_objects if len(obj.vertex_groups) > 0)
+armature_modifiers = sum(
+    1
+    for obj in mesh_objects
+    for modifier in obj.modifiers
+    if modifier.type == "ARMATURE"
+)
+color_attributes = sum(len(obj.data.color_attributes) for obj in mesh_objects)
+
+summary = {
+    "asset": args.asset,
+    "format": extension.removeprefix("."),
+    "importResult": sorted(import_result),
+    "objects": len(bpy.context.scene.objects),
+    "meshObjects": len(mesh_objects),
+    "namedMeshObjects": sum(1 for obj in mesh_objects if bool(obj.name)),
+    "armatures": len(armatures),
+    "bones": sum(len(obj.data.bones) for obj in armatures),
+    "weightedMeshes": weighted_meshes,
+    "armatureModifiers": armature_modifiers,
+    "materials": len(materials),
+    "texturedMaterials": textured_materials,
+    "images": len(images),
+    "packedImages": sum(1 for image in images if image.packed_file is not None),
+    "colorAttributes": color_attributes,
+    "actions": len(actions),
+    "actionSlots": sum(len(action.slots) for action in actions),
+    "actionNames": [action.name for action in actions],
+}
+if not args.summary_only:
+    summary["meshNames"] = [obj.name for obj in mesh_objects]
+
+requirements = {
+    "meshObjects": args.min_meshes,
+    "bones": args.min_bones,
+    "weightedMeshes": args.min_weighted_meshes,
+    "actions": args.min_actions,
+    "images": args.min_images,
+    "texturedMaterials": args.min_textured_materials,
+    "colorAttributes": args.min_color_attributes,
+}
+failures = [
+    f"{field}: expected >= {minimum}, found {summary[field]}"
+    for field, minimum in requirements.items()
+    if summary[field] < minimum
+]
+summary["requirements"] = requirements
+summary["failures"] = failures
+summary["passed"] = not failures and "FINISHED" in import_result
+print("IMG2THREEJS_BLENDER " + json.dumps(summary, ensure_ascii=False, sort_keys=True))
+if not summary["passed"]:
+    raise SystemExit(1)

--- a/src/demos/sony-wf1000xm3/createSonyWf1000xm3Model.ts
+++ b/src/demos/sony-wf1000xm3/createSonyWf1000xm3Model.ts
@@ -208,7 +208,11 @@ const WELL_FLOOR_Y = 0.5;
 export function createSonyWf1000xm3Model(options: SonyWf1000xm3Options = {}): THREE.Group {
   const shadows = options.shadows ?? true;
   const root = new THREE.Group();
+  root.name = 'sonyWf1000xm3Set';
   root.position.y = 0.16; // hover so the tilt never clips the contact-shadow plane
+  const caseGroup = new THREE.Group();
+  caseGroup.name = 'chargingCase';
+  root.add(caseGroup);
 
   /* ---- materials ---- */
   const matBody = new THREE.MeshPhysicalMaterial({
@@ -305,7 +309,8 @@ export function createSonyWf1000xm3Model(options: SonyWf1000xm3Options = {}): TH
 
   /* ---- BODY ---- */
   const bodyGroup = new THREE.Group();
-  root.add(bodyGroup);
+  bodyGroup.name = 'caseBody';
+  caseGroup.add(bodyGroup);
 
   // ONE smooth full-height body shell with two real oval well through-holes.
   // Single extruded piece → continuous rounded exterior, no mid-height seam.
@@ -392,8 +397,9 @@ export function createSonyWf1000xm3Model(options: SonyWf1000xm3Options = {}): TH
 
   /* ---- LID (copper, rear hinge) ---- */
   const lidPivot = new THREE.Group();
+  lidPivot.name = 'caseLidPivot';
   lidPivot.position.set(0, topY - 0.1, -CASE_DEP / 2 + 0.06);
-  root.add(lidPivot);
+  caseGroup.add(lidPivot);
 
   const lidGroup = new THREE.Group();
   lidPivot.add(lidGroup);
@@ -509,8 +515,15 @@ export function createSonyWf1000xm3Model(options: SonyWf1000xm3Options = {}): TH
 
   const budL = makeEarbud(-1);
   const budR = makeEarbud(1);
+  budL.name = 'leftEarbud';
+  budR.name = 'rightEarbud';
   root.add(budL);
   root.add(budR);
+  root.userData.exportModels = [
+    { id: 'charging-case', label: 'Charging case', root: caseGroup },
+    { id: 'left-earbud', label: 'Left earbud', root: budL },
+    { id: 'right-earbud', label: 'Right earbud', root: budR },
+  ];
 
   const seat = {
     L: { pos: new THREE.Vector3(-WELL_X, topY - 0.06, 0.02), rot: new THREE.Euler(0.15, 0, 0.05) },

--- a/src/demos/starship-super-heavy/createStarshipSuperHeavyModel.ts
+++ b/src/demos/starship-super-heavy/createStarshipSuperHeavyModel.ts
@@ -225,6 +225,12 @@ export function createStarshipSuperHeavyModel(
 
   const modeledShipHeight=27.9+originalShipBodyHeight*(axialLengthScale-1);
   root.userData.sculptRuntime={nodes:{root,booster,ship,engineGroup,shipEngines,heatShieldTiles},sockets:{stageSeparation:{position:[0,38.1*axialLengthScale,0]},payload:{position:[0,38.1*axialLengthScale+26.7+originalShipBodyHeight*(axialLengthScale-1),0]}},colliders:[{id:'booster',type:'cylinder',radius:3.25,height:38.8*axialLengthScale},{id:'ship',type:'compound',height:modeledShipHeight}],dimensions:{sourceMeters:{starship:52.1,superHeavy:72.3},boosterAxialScale:axialLengthScale,shipBodyAxialScale:axialLengthScale,shipFairingAxialScale:1,modeledUnits:{starship:modeledShipHeight,superHeavy:38.8*axialLengthScale}},repetitionSystems:{heatShieldTiles:{count:heatShieldTiles.count,type:'hex-instanced'},boosterEngines:{count:boosterEnginePositions.length,uniformScale:boosterEngineScale,layout:'reference-fitted',visibleReferenceCenters:32,inferredCenters:1,positions:boosterEnginePositions},shipEngines:{count:7,center:1,outerRing:6,outerRingRadius:1.58,positions:starshipEnginePositions}},destructionGroups:{booster:'superHeavy',upperStage:'starship'}};
+  // Export roots are explicit: the exporter must not mistake flaps, engines or tile groups for
+  // separate models. Each root owns the full geometry needed for a useful standalone DCC import.
+  root.userData.exportModels = [
+    { id: 'super-heavy', label: 'Super Heavy booster', root: booster },
+    { id: 'starship', label: 'Starship upper stage', root: ship },
+  ];
   const stackedShipPosition = ship.position.clone();
   const raisedShipPosition = new THREE.Vector3(0, 49.8, 0);
   const acrossShipPosition = new THREE.Vector3(12, 49.8, 0);

--- a/src/export.css
+++ b/src/export.css
@@ -1,0 +1,384 @@
+/* ---- validated asset export ---- */
+
+.demo-export {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 0.8rem;
+  border: 1px solid color-mix(in srgb, var(--accent, var(--amber)) 32%, var(--border));
+  border-radius: 0.65rem;
+  background:
+    linear-gradient(145deg, color-mix(in srgb, var(--accent, var(--amber)) 7%, transparent), transparent 55%),
+    rgba(0, 0, 0, 0.16);
+}
+
+.demo-export-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.demo-export-head > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.16rem;
+}
+
+.demo-export-subtitle {
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.demo-export-status {
+  flex: 0 0 auto;
+  max-width: 54%;
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.06em;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+.demo-export-status[data-state='busy'] { color: var(--accent-strong); }
+.demo-export-status[data-state='success'] { color: #71d69b; }
+.demo-export-status[data-state='warning'] { color: #e8bc70; }
+.demo-export-status[data-state='error'] { color: #ff7d7d; }
+
+.demo-export-formats {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.demo-export-scope {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.42rem 0.62rem;
+  padding: 0.58rem 0.62rem;
+  border: 1px solid var(--border);
+  border-radius: 0.48rem;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.demo-export-scope[hidden] { display: none; }
+
+.demo-export-scope label {
+  color: var(--accent-strong);
+  font-family: var(--mono);
+  font-size: 0.61rem;
+  font-weight: 700;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+}
+
+.demo-export-scope select {
+  width: 100%;
+  min-width: 0;
+  min-height: 2.15rem;
+  padding: 0.4rem 2rem 0.4rem 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--accent, var(--amber)) 38%, var(--border));
+  border-radius: 0.38rem;
+  background: color-mix(in srgb, var(--bg, #101116) 88%, transparent);
+  color: var(--text);
+  font: 600 0.68rem/1.2 var(--mono);
+}
+
+.demo-export-scope select:focus-visible {
+  border-color: var(--accent-strong);
+  outline: 2px solid color-mix(in srgb, var(--accent, var(--amber)) 34%, transparent);
+  outline-offset: 2px;
+}
+
+.demo-export-scope p {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 0.61rem;
+  line-height: 1.45;
+}
+
+.demo-export-format-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 2.35rem;
+  gap: 0.36rem;
+  min-width: 0;
+}
+
+.demo-export-format {
+  display: grid;
+  grid-template-columns: 3.3rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  min-width: 0;
+  padding: 0.58rem 0.62rem;
+  border: 1px solid var(--border);
+  border-radius: 0.48rem;
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background 0.18s ease, transform 0.18s ease;
+}
+
+.demo-export-info {
+  display: grid;
+  place-items: center;
+  min-width: 2.35rem;
+  min-height: 2.35rem;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  align-self: center;
+  aspect-ratio: 1;
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--text-dim);
+  font: 700 0.68rem/1 var(--mono);
+  cursor: help;
+  transition: border-color 0.18s ease, background 0.18s ease, color 0.18s ease, transform 0.18s ease;
+}
+
+.demo-export-info:hover,
+.demo-export-info:focus-visible,
+.demo-export-format-row.is-info-open .demo-export-info {
+  border-color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent, var(--amber)) 12%, transparent);
+  color: var(--accent-strong);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.demo-export-info:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent, var(--amber)) 30%, transparent);
+}
+
+.demo-export-tooltip {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.38rem);
+  z-index: 6;
+  display: none;
+  width: min(22rem, calc(100% - 0.2rem));
+  max-height: min(18rem, 50vh);
+  overflow: auto;
+  padding: 0.72rem;
+  border: 1px solid color-mix(in srgb, var(--accent, var(--amber)) 48%, var(--border));
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--bg, #101116) 94%, #fff 6%);
+  box-shadow: 0 0.9rem 2.2rem rgba(0, 0, 0, 0.42);
+  color: var(--text-dim);
+  font-size: 0.63rem;
+  line-height: 1.48;
+}
+
+.demo-export-info:hover + .demo-export-tooltip,
+.demo-export-info:focus + .demo-export-tooltip,
+.demo-export-info:focus-visible + .demo-export-tooltip,
+.demo-export-format-row.is-info-open .demo-export-tooltip {
+  display: block;
+}
+
+.demo-export-tooltip strong {
+  display: block;
+  margin-bottom: 0.46rem;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
+.demo-export-tooltip p { margin: 0.34rem 0 0; }
+
+.demo-export-tooltip p span {
+  display: inline-block;
+  min-width: 3.2rem;
+  margin-right: 0.32rem;
+  color: var(--accent-strong);
+  font-family: var(--mono);
+  font-size: 0.56rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.demo-export-format:hover:not(:disabled),
+.demo-export-format:focus-visible {
+  border-color: color-mix(in srgb, var(--accent, var(--amber)) 65%, var(--border));
+  background: color-mix(in srgb, var(--accent, var(--amber)) 9%, transparent);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.demo-export-format:disabled {
+  cursor: wait;
+  opacity: 0.48;
+}
+
+.demo-export-format.is-exporting {
+  border-color: var(--accent, var(--amber));
+  opacity: 1;
+}
+
+.demo-export-label {
+  color: var(--accent-strong);
+  font-family: var(--mono);
+  font-size: 0.77rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.demo-export-note {
+  min-width: 0;
+  color: var(--text-dim);
+  font-size: 0.68rem;
+  line-height: 1.35;
+}
+
+.demo-export-arrow {
+  color: var(--accent-strong);
+  font-size: 0.9rem;
+  transition: transform 0.18s ease;
+}
+
+.demo-export-format:hover:not(:disabled) .demo-export-arrow {
+  transform: translateY(2px);
+}
+
+.demo-export-format.is-exporting .demo-export-arrow {
+  animation: export-arrow 0.8s ease-in-out infinite alternate;
+}
+
+.demo-export-all {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  min-width: 0;
+  min-height: 3.35rem;
+  padding: 0.66rem 0.72rem;
+  border: 1px solid color-mix(in srgb, var(--accent, var(--amber)) 55%, var(--border));
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--accent, var(--amber)) 10%, rgba(255, 255, 255, 0.025));
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background 0.18s ease, transform 0.18s ease;
+}
+
+.demo-export-all > span:first-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.17rem;
+}
+
+.demo-export-all strong {
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+}
+
+.demo-export-all small {
+  color: var(--text-dim);
+  font-size: 0.61rem;
+  line-height: 1.35;
+}
+
+.demo-export-zip {
+  flex: 0 0 auto;
+  color: var(--accent-strong);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.demo-export-all:hover:not(:disabled),
+.demo-export-all:focus-visible {
+  border-color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent, var(--amber)) 16%, transparent);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.demo-export-all:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent, var(--amber)) 28%, transparent);
+}
+
+.demo-export-all:active:not(:disabled) { transform: translateY(1px); }
+
+.demo-export-all:disabled {
+  cursor: wait;
+  opacity: 0.48;
+}
+
+.demo-export-all.is-exporting {
+  border-color: var(--accent-strong);
+  opacity: 1;
+}
+
+.demo-export-all.is-exporting .demo-export-zip {
+  animation: export-arrow 0.8s ease-in-out infinite alternate;
+}
+
+@keyframes export-arrow {
+  to { transform: translateY(4px); }
+}
+
+.demo-export-report {
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 0.67rem;
+  line-height: 1.5;
+}
+
+.demo-export-report p {
+  margin: 0;
+  color: var(--text);
+}
+
+.demo-export-report ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1.05rem;
+  color: #e8bc70;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .demo-export-format,
+  .demo-export-arrow,
+  .demo-export-info,
+  .demo-export-all { transition: none; }
+  .demo-export-format.is-exporting .demo-export-arrow,
+  .demo-export-all.is-exporting .demo-export-zip { animation: none; }
+}
+
+@media (max-width: 960px) {
+  .demo-export-tooltip {
+    position: static;
+    grid-column: 1 / -1;
+    width: auto;
+    max-height: none;
+    box-shadow: none;
+  }
+}
+
+@media (max-width: 520px) {
+  .demo-export-scope { grid-template-columns: 1fr; }
+  .demo-export-scope p { grid-column: 1; }
+  .demo-export-format-row { grid-template-columns: minmax(0, 1fr) 2.2rem; }
+  .demo-export-info { min-width: 2.2rem; min-height: 2.2rem; }
+  .demo-export-all { align-items: flex-start; }
+}

--- a/src/exporters.ts
+++ b/src/exporters.ts
@@ -1,0 +1,1798 @@
+import * as THREE from 'three';
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
+import { OBJExporter } from 'three/examples/jsm/exporters/OBJExporter.js';
+import { PLYExporter } from 'three/examples/jsm/exporters/PLYExporter.js';
+import { STLExporter } from 'three/examples/jsm/exporters/STLExporter.js';
+import { USDZExporter } from 'three/examples/jsm/exporters/USDZExporter.js';
+import {
+  Zip,
+  ZipPassThrough,
+  strFromU8,
+  strToU8,
+  unzipSync,
+  zipSync,
+} from 'three/examples/jsm/libs/fflate.module.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { clone as cloneSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.js';
+
+/** Formats exposed by the showcase viewer. */
+export type ExportFormat = 'glb' | 'gltf' | 'obj' | 'stl' | 'ply' | 'usdz';
+
+export interface ExportFormatDefinition {
+  format: ExportFormat;
+  label: string;
+  note: string;
+  keeps: string;
+  limits: string;
+}
+
+export const EXPORT_FORMATS: ReadonlyArray<ExportFormatDefinition> = [
+  {
+    format: 'glb',
+    label: 'GLB',
+    note: 'binary glTF — hierarchy, materials, textures, rig & clips',
+    keeps: 'Mesh hierarchy and names, PBR materials, embedded textures, UVs, normals, vertex colours, morphs, skin weights, armatures and portable animation clips.',
+    limits: 'Procedural JavaScript motion, runtime VFX, post-processing and custom shader behaviour cannot be reconstructed in Blender or other DCC tools.',
+  },
+  {
+    format: 'gltf',
+    label: 'glTF',
+    note: 'same portable scene as readable JSON',
+    keeps: 'The same scene data as GLB: hierarchy, names, materials, embedded textures, rigging, morphs and portable clips, stored as readable JSON.',
+    limits: 'Runtime VFX, JavaScript controllers, post-processing and custom shader behaviour are outside the glTF interchange format.',
+  },
+  {
+    format: 'obj',
+    label: 'OBJ',
+    note: 'named meshes + geometry + normals + UVs',
+    keeps: 'Current posed geometry, named mesh boundaries, normals and UV coordinates.',
+    limits: 'This single-file OBJ has no MTL, image textures, material graph, rig, skin weights, morph targets, clips or runtime VFX.',
+  },
+  {
+    format: 'stl',
+    label: 'STL',
+    note: 'baked triangles — for 3D printing',
+    keeps: 'Current posed surface as validated binary triangles.',
+    limits: 'Hierarchy, part names, materials, textures, colours, UVs, rigging, morphs, animation and VFX are not represented.',
+  },
+  {
+    format: 'ply',
+    label: 'PLY',
+    note: 'baked geometry + existing vertex colours',
+    keeps: 'Current posed geometry, normals, UV coordinates and vertex colours that already exist on the source meshes.',
+    limits: 'The assembly is flattened; named parts, material graphs, image textures, rigging, morphs, clips and VFX are omitted.',
+  },
+  {
+    format: 'usdz',
+    label: 'USDZ',
+    note: 'posed AR preview with normalized materials',
+    keeps: 'Current posed geometry plus Quick Look-compatible normalized PBR materials and portable image textures.',
+    limits: 'Three.js r169 exports a posed preview, not editable armatures or clips; custom shaders, procedural motion and runtime VFX are approximated or omitted.',
+  },
+];
+
+/** A deliberately declared, independently exportable model within a showcase assembly. */
+export interface ExportModelScope {
+  id: string;
+  label: string;
+  root: THREE.Object3D;
+}
+
+export interface ExportReport {
+  format: ExportFormat;
+  bytes: number;
+  meshCount: number;
+  triangleCount: number;
+  namedPartCount: number;
+  materialCount: number;
+  portableMaterialCount: number;
+  textureCount: number;
+  portableTextureCount: number;
+  texturedMaterialCount: number;
+  textureBindingCount: number;
+  uvMeshCount: number;
+  vertexColourMeshCount: number;
+  skinnedMeshCount: number;
+  jointCount: number;
+  sourceAnimationCount: number;
+  animationCount: number;
+  animationTrackCount: number;
+  morphTargetCount: number;
+  instanceCount: number;
+  roundTripValidated: boolean;
+  warnings: string[];
+}
+
+export interface ExportArtifact {
+  blob: Blob;
+  filenameExtension: ExportFormat;
+  report: ExportReport;
+}
+
+export interface ExportBundleProgress {
+  format: ExportFormat;
+  label: string;
+  index: number;
+  total: number;
+}
+
+export interface ExportBundleArtifact {
+  blob: Blob;
+  filename: string;
+  files: string[];
+  reports: ExportReport[];
+}
+
+export interface ExportBundleOptions {
+  assetId: string;
+  scopeId: string;
+  scopeLabel: string;
+  snapshot?: ExportSnapshot;
+  selectedRoot?: THREE.Object3D;
+  onProgress?: (progress: ExportBundleProgress) => void;
+}
+
+/**
+ * Viewer tools such as explode, isolate and rig-debug temporarily alter the live model. The viewer
+ * supplies a synchronous snapshot boundary so cloning sees the authored assembly while animation
+ * bones retain the pose currently displayed on stage.
+ */
+export type ExportSnapshot = <T>(snapshot: () => T) => T;
+
+interface AssetInventory {
+  meshCount: number;
+  triangleCount: number;
+  namedPartCount: number;
+  materialCount: number;
+  portableMaterialCount: number;
+  textureCount: number;
+  texturedMaterialCount: number;
+  portableTextureCount: number;
+  textureBindingCount: number;
+  uvMeshCount: number;
+  skinnedMeshCount: number;
+  jointCount: number;
+  morphTargetCount: number;
+  vertexColourMeshCount: number;
+  instancedMeshCount: number;
+  instanceCount: number;
+  unsupportedRenderableCount: number;
+  nonPbrMaterialCount: number;
+  namedParts: string[];
+}
+
+interface PreparedAnimations {
+  clips: THREE.AnimationClip[];
+  sourceCount: number;
+  droppedTracks: number;
+}
+
+const ROUND_TRIP_TRIANGLE_LIMIT = 750_000;
+const INSTANCE_SCALE_EPSILON = 1e-8;
+const COMPONENT_INDEX: Readonly<Record<string, number>> = { x: 0, y: 1, z: 2, w: 3 };
+const DIRECT_GLTF_TEXTURE_KEYS = [
+  'map',
+  'emissiveMap',
+  'normalMap',
+  'aoMap',
+  'clearcoatMap',
+  'clearcoatRoughnessMap',
+  'clearcoatNormalMap',
+  'iridescenceMap',
+  'iridescenceThicknessMap',
+  'transmissionMap',
+  'thicknessMap',
+  'specularIntensityMap',
+  'specularColorMap',
+  'sheenRoughnessMap',
+  'sheenColorMap',
+  'anisotropyMap',
+  'bumpMap',
+] as const;
+
+function isAnimationClip(value: unknown): value is THREE.AnimationClip {
+  return value instanceof THREE.AnimationClip
+    || (!!value && typeof value === 'object' && Array.isArray((value as THREE.AnimationClip).tracks));
+}
+
+/** Collect clips from every runtime contract used by the showcase, including lazy child rigs. */
+export function animationsFor(root: THREE.Object3D): THREE.AnimationClip[] {
+  const clips: THREE.AnimationClip[] = [];
+  const seen = new Set<string>();
+  const add = (value: unknown): void => {
+    if (!Array.isArray(value)) return;
+    for (const clip of value) {
+      if (!isAnimationClip(clip)) continue;
+      const key = clip.uuid || `${clip.name}:${clip.duration}:${clip.tracks.length}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      clips.push(clip);
+    }
+  };
+
+  root.traverse((node) => {
+    add(node.animations);
+    add(node.userData.animationClips);
+    const rigged = node.userData.rigged as { clips?: unknown } | undefined;
+    add(rigged?.clips);
+    const runtime = node.userData.sculptRuntime as {
+      animationClips?: unknown;
+      clips?: unknown;
+    } | undefined;
+    add(runtime?.animationClips);
+    add(runtime?.clips);
+  });
+  return clips;
+}
+
+function hasVisibleExportMesh(root: THREE.Object3D): boolean {
+  let found = false;
+  root.traverseVisible((node) => {
+    if ((node as THREE.Mesh).isMesh) found = true;
+  });
+  return found;
+}
+
+function belongsToAssembly(assembly: THREE.Object3D, candidate: THREE.Object3D): boolean {
+  let current: THREE.Object3D | null = candidate;
+  while (current) {
+    if (current === assembly) return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+/**
+ * Read the explicit multi-model contract from a showcase root. This intentionally does not infer
+ * models from child groups: characters and procedural objects often use the same structure for
+ * bones, parts and VFX, so inference would present a destructive and misleading export choice.
+ */
+export function exportModelsFor(assembly: THREE.Group): ExportModelScope[] {
+  const runtime = assembly.userData.sculptRuntime as { exportModels?: unknown } | undefined;
+  const declared = assembly.userData.exportModels ?? runtime?.exportModels;
+  if (!Array.isArray(declared)) return [];
+
+  const result: ExportModelScope[] = [];
+  const ids = new Set<string>();
+  const roots = new Set<THREE.Object3D>();
+  for (const value of declared) {
+    if (!value || typeof value !== 'object') continue;
+    const item = value as { id?: unknown; label?: unknown; root?: unknown };
+    if (typeof item.id !== 'string' || typeof item.label !== 'string') continue;
+    const root = item.root as THREE.Object3D | undefined;
+    if (!root?.isObject3D || root === assembly || !belongsToAssembly(assembly, root)) continue;
+    const id = item.id.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+    const label = item.label.trim();
+    if (!id || !label || ids.has(id) || roots.has(root) || !hasVisibleExportMesh(root)) continue;
+    ids.add(id);
+    roots.add(root);
+    result.push({ id, label, root });
+  }
+  return result;
+}
+
+function materialList(mesh: THREE.Mesh): THREE.Material[] {
+  return Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+}
+
+function usedMaterialList(mesh: THREE.Mesh): THREE.Material[] {
+  if (!Array.isArray(mesh.material)) return [mesh.material];
+  const materials = mesh.material;
+  if (!mesh.geometry.groups.length) return [];
+  const indices = new Set(mesh.geometry.groups.map((group) => group.materialIndex ?? 0));
+  return [...indices]
+    .map((index) => materials[index])
+    .filter((material): material is THREE.Material => !!material);
+}
+
+function allMaterialTextures(material: THREE.Material): THREE.Texture[] {
+  const textures = new Set<THREE.Texture>();
+  const add = (value: unknown): void => {
+    if (value instanceof THREE.Texture) textures.add(value);
+    else if (Array.isArray(value)) for (const item of value) add(item);
+  };
+  const record = material as unknown as Record<string, unknown>;
+  for (const value of Object.values(record)) add(value);
+  const shader = material as THREE.ShaderMaterial;
+  if (shader.isShaderMaterial) {
+    for (const uniform of Object.values(shader.uniforms)) add(uniform?.value);
+  }
+  return [...textures];
+}
+
+/** Texture slots which GLTFExporter r169 can map to core glTF or a registered material extension. */
+function portableMaterialTextures(material: THREE.Material): {
+  textures: THREE.Texture[];
+  bindingCount: number;
+} {
+  const record = material as unknown as Record<string, unknown>;
+  const textures = new Set<THREE.Texture>();
+  let bindingCount = 0;
+  for (const key of DIRECT_GLTF_TEXTURE_KEYS) {
+    const value = record[key];
+    if (!(value instanceof THREE.Texture)) continue;
+    textures.add(value);
+    bindingCount += 1;
+  }
+  // glTF packs these two scalar channels into one metallic-roughness texture binding.
+  const metalness = record.metalnessMap;
+  const roughness = record.roughnessMap;
+  if (metalness instanceof THREE.Texture || roughness instanceof THREE.Texture) {
+    if (metalness instanceof THREE.Texture) textures.add(metalness);
+    if (roughness instanceof THREE.Texture) textures.add(roughness);
+    bindingCount += 1;
+  }
+  return { textures: [...textures], bindingCount };
+}
+
+function dataTextureAsCanvas(texture: THREE.DataTexture): THREE.Texture {
+  const image = texture.image as {
+    data?: ArrayLike<number>;
+    width?: number;
+    height?: number;
+  };
+  const width = image.width ?? 0;
+  const height = image.height ?? 0;
+  const source = image.data;
+  if (!source || width < 1 || height < 1 || typeof document === 'undefined') return texture;
+  const pixels = width * height;
+  const channels = Math.max(1, Math.min(4, Math.round(source.length / pixels)));
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext('2d');
+  if (!context) return texture;
+  const rgba = context.createImageData(width, height);
+  const maximum = source instanceof Uint16Array ? 65535
+    : source instanceof Float32Array ? 1
+      : 255;
+  const byte = (value: number): number => Math.round(THREE.MathUtils.clamp(value / maximum, 0, 1) * 255);
+  for (let pixel = 0; pixel < pixels; pixel += 1) {
+    const at = pixel * channels;
+    const out = pixel * 4;
+    const r = byte(source[at] ?? 0);
+    const g = channels > 1 ? byte(source[at + 1] ?? 0) : r;
+    const b = channels > 2 ? byte(source[at + 2] ?? 0) : r;
+    rgba.data[out] = r;
+    rgba.data[out + 1] = g;
+    rgba.data[out + 2] = b;
+    rgba.data[out + 3] = channels > 3 ? byte(source[at + 3] ?? maximum) : 255;
+  }
+  context.putImageData(rgba, 0, 0);
+  const converted = texture.clone();
+  converted.source = new THREE.Source(canvas);
+  converted.needsUpdate = true;
+  return converted;
+}
+
+/** GLTFExporter r169 cannot draw raw DataTexture.image records while packing PBR channels. */
+function normalizeMaterialTextures(
+  material: THREE.Material,
+  convertedTextures = new Map<THREE.DataTexture, THREE.Texture>(),
+): void {
+  const record = material as unknown as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    const value = record[key];
+    if (!(value instanceof THREE.DataTexture)) continue;
+    let converted = convertedTextures.get(value);
+    if (!converted) {
+      converted = dataTextureAsCanvas(value);
+      convertedTextures.set(value, converted);
+    }
+    record[key] = converted;
+  }
+}
+
+function triangleCount(geometry: THREE.BufferGeometry): number {
+  return (geometry.index?.count ?? geometry.getAttribute('position')?.count ?? 0) / 3;
+}
+
+/**
+ * EXT_mesh_gpu_instancing decomposes every matrix to TRS. A valid zero-scale matrix has no
+ * recoverable rotation, and Three's Matrix4.decompose() consequently emits a NaN quaternion.
+ * Preserve translation/scale and choose the neutral rotation only for those singular instances.
+ * Zero scale is raised to a visually inert epsilon because the exporter decomposes the matrix again.
+ */
+function stabilizeInstanceMatrices(root: THREE.Object3D): number {
+  const matrix = new THREE.Matrix4();
+  const position = new THREE.Vector3();
+  const quaternion = new THREE.Quaternion();
+  const scale = new THREE.Vector3();
+  const column = new THREE.Vector3();
+  let stabilized = 0;
+  root.traverse((node) => {
+    const mesh = node as THREE.InstancedMesh;
+    if (!mesh.isInstancedMesh) return;
+    let changed = false;
+    for (let i = 0; i < mesh.count; i += 1) {
+      mesh.getMatrixAt(i, matrix);
+      matrix.decompose(position, quaternion, scale);
+      if ([...position.toArray(), ...quaternion.toArray(), ...scale.toArray()].every(Number.isFinite)) continue;
+      const elements = matrix.elements;
+      position.set(elements[12], elements[13], elements[14]);
+      scale.set(
+        Math.max(column.set(elements[0], elements[1], elements[2]).length(), INSTANCE_SCALE_EPSILON),
+        Math.max(column.set(elements[4], elements[5], elements[6]).length(), INSTANCE_SCALE_EPSILON),
+        Math.max(column.set(elements[8], elements[9], elements[10]).length(), INSTANCE_SCALE_EPSILON),
+      );
+      quaternion.identity();
+      matrix.compose(position, quaternion, scale);
+      mesh.setMatrixAt(i, matrix);
+      stabilized += 1;
+      changed = true;
+    }
+    if (changed) mesh.instanceMatrix.needsUpdate = true;
+  });
+  return stabilized;
+}
+
+function inventory(root: THREE.Object3D): AssetInventory {
+  const meshNames: string[] = [];
+  const bones = new Set<THREE.Bone>();
+  const materials = new Set<THREE.Material>();
+  const textures = new Set<THREE.Texture>();
+  const portableTextures = new Set<THREE.Texture>();
+  let meshCount = 0;
+  let triangles = 0;
+  let uvMeshCount = 0;
+  let skinnedMeshCount = 0;
+  let morphTargetCount = 0;
+  let vertexColourMeshCount = 0;
+  let instancedMeshCount = 0;
+  let instanceCount = 0;
+  let unsupportedRenderableCount = 0;
+  let textureBindingCount = 0;
+  let texturedMaterialCount = 0;
+
+  root.traverseVisible((node) => {
+    if ((node as THREE.Points).isPoints || (node as THREE.Line).isLine || (node as THREE.Sprite).isSprite) {
+      unsupportedRenderableCount += 1;
+      return;
+    }
+    const mesh = node as THREE.Mesh;
+    if (!mesh.isMesh) return;
+    meshCount += 1;
+    if (mesh.name) meshNames.push(mesh.name);
+    const instanced = mesh as THREE.InstancedMesh;
+    const copies = instanced.isInstancedMesh ? instanced.count : 1;
+    triangles += triangleCount(mesh.geometry) * copies;
+    if (instanced.isInstancedMesh) {
+      instancedMeshCount += 1;
+      instanceCount += instanced.count;
+    }
+    const skinned = mesh as THREE.SkinnedMesh;
+    if (skinned.isSkinnedMesh) {
+      skinnedMeshCount += 1;
+      for (const bone of skinned.skeleton.bones) bones.add(bone);
+    }
+    const targets = Object.values(mesh.geometry.morphAttributes)
+      .reduce((max, attrs) => Math.max(max, attrs.length), 0);
+    morphTargetCount += targets;
+    if (mesh.geometry.getAttribute('uv')) uvMeshCount += 1;
+    if (mesh.geometry.getAttribute('color')) vertexColourMeshCount += 1;
+    for (const material of usedMaterialList(mesh)) materials.add(material);
+  });
+
+  let nonPbrMaterialCount = 0;
+  let portableMaterialCount = 0;
+  for (const material of materials) {
+    const materialTextures = allMaterialTextures(material);
+    if (materialTextures.length) texturedMaterialCount += 1;
+    for (const texture of materialTextures) textures.add(texture);
+    const portable = portableMaterialTextures(material);
+    textureBindingCount += portable.bindingCount;
+    for (const texture of portable.textures) portableTextures.add(texture);
+    if (!(material as THREE.MeshStandardMaterial).isMeshStandardMaterial
+      && !(material as THREE.MeshBasicMaterial).isMeshBasicMaterial) {
+      nonPbrMaterialCount += 1;
+    }
+    if (!(material as THREE.ShaderMaterial).isShaderMaterial) portableMaterialCount += 1;
+  }
+
+  return {
+    meshCount,
+    triangleCount: Math.round(triangles),
+    namedPartCount: meshNames.length,
+    materialCount: materials.size,
+    portableMaterialCount,
+    textureCount: textures.size,
+    texturedMaterialCount,
+    portableTextureCount: portableTextures.size,
+    textureBindingCount,
+    uvMeshCount,
+    skinnedMeshCount,
+    jointCount: bones.size,
+    morphTargetCount,
+    vertexColourMeshCount,
+    instancedMeshCount,
+    instanceCount,
+    unsupportedRenderableCount,
+    nonPbrMaterialCount,
+    // Mesh names are the DCC-facing physical parts and must survive byte-for-byte (or through the
+    // exporter's documented PropertyBinding sanitization). Named parent groups still contribute to
+    // namedPartCount and hierarchy, but are not a reliable identity contract after importer grouping.
+    namedParts: meshNames,
+  };
+}
+
+function runtimeCapabilities(root: THREE.Object3D): {
+  hasAnimationController: boolean;
+  hasVfxRuntime: boolean;
+} {
+  let hasAnimationController = false;
+  let hasVfxRuntime = false;
+  root.traverse((node) => {
+    const runtime = node.userData.sculptRuntime as {
+      animationController?: unknown;
+      strikeVfx?: unknown;
+      vfx?: unknown;
+    } | undefined;
+    if (runtime?.animationController) hasAnimationController = true;
+    if (runtime?.strikeVfx || runtime?.vfx) hasVfxRuntime = true;
+    if ((node as THREE.Points).isPoints || (node as THREE.Line).isLine || (node as THREE.Sprite).isSprite) {
+      hasVfxRuntime = true;
+    }
+    const mesh = node as THREE.Mesh;
+    if (mesh.isMesh && materialList(mesh).some((material) => (material as THREE.ShaderMaterial).isShaderMaterial)) {
+      hasVfxRuntime = true;
+    }
+  });
+  return { hasAnimationController, hasVfxRuntime };
+}
+
+/** Fail before an exporter turns broken geometry or skinning into a plausible-looking file. */
+function validateGeometry(root: THREE.Object3D): AssetInventory {
+  root.updateMatrixWorld(true);
+  let visibleMeshes = 0;
+  const matrix = new THREE.Matrix4();
+  const instancePosition = new THREE.Vector3();
+  const instanceQuaternion = new THREE.Quaternion();
+  const instanceScale = new THREE.Vector3();
+  root.traverseVisible((node) => {
+    if (!node.matrixWorld.elements.every(Number.isFinite)) {
+      throw new Error(`Export failed: ${node.name || node.type} has a non-finite world transform`);
+    }
+    const mesh = node as THREE.Mesh;
+    if (!mesh.isMesh) return;
+    visibleMeshes += 1;
+    const position = mesh.geometry.getAttribute('position');
+    if (!position || position.count < 3) {
+      throw new Error(`Export failed: ${mesh.name || 'mesh'} has no triangle positions`);
+    }
+    for (let i = 0; i < position.count; i += 1) {
+      for (let component = 0; component < position.itemSize; component += 1) {
+        if (!Number.isFinite(position.getComponent(i, component))) {
+          throw new Error(`Export failed: ${mesh.name || 'mesh'} contains a non-finite vertex`);
+        }
+      }
+    }
+    const index = mesh.geometry.getIndex();
+    const count = index?.count ?? position.count;
+    if (!count || count % 3 !== 0) {
+      throw new Error(`Export failed: ${mesh.name || 'mesh'} is not triangle geometry`);
+    }
+    if (index) {
+      for (let i = 0; i < index.count; i += 1) {
+        const value = index.getX(i);
+        if (!Number.isInteger(value) || value < 0 || value >= position.count) {
+          throw new Error(`Export failed: ${mesh.name || 'mesh'} has an out-of-range index`);
+        }
+      }
+    }
+    for (const [name, attrs] of Object.entries(mesh.geometry.morphAttributes)) {
+      for (const attribute of attrs) {
+        if (attribute.count !== position.count) {
+          throw new Error(`Export failed: ${mesh.name || 'mesh'} morph ${name} has the wrong vertex count`);
+        }
+      }
+    }
+
+    const instanced = mesh as THREE.InstancedMesh;
+    if (instanced.isInstancedMesh) {
+      if (!Number.isInteger(instanced.count) || instanced.count < 1) {
+        throw new Error(`Export failed: ${mesh.name || 'instanced mesh'} has no instances`);
+      }
+      for (let i = 0; i < instanced.count; i += 1) {
+        instanced.getMatrixAt(i, matrix);
+        if (!matrix.elements.every(Number.isFinite)) {
+          throw new Error(`Export failed: ${mesh.name || 'instanced mesh'} instance ${i} has an invalid transform`);
+        }
+        matrix.decompose(instancePosition, instanceQuaternion, instanceScale);
+        if (![...instancePosition.toArray(), ...instanceQuaternion.toArray(), ...instanceScale.toArray()]
+          .every(Number.isFinite)) {
+          throw new Error(
+            `Export failed: ${mesh.name || 'instanced mesh'} instance ${i} cannot be represented as glTF TRS`,
+          );
+        }
+      }
+    }
+
+    const skinned = mesh as THREE.SkinnedMesh;
+    if (!skinned.isSkinnedMesh) return;
+    const skinIndex = mesh.geometry.getAttribute('skinIndex');
+    const skinWeight = mesh.geometry.getAttribute('skinWeight');
+    if (!skinIndex || !skinWeight || skinIndex.count !== position.count || skinWeight.count !== position.count) {
+      throw new Error(`Export failed: ${mesh.name || 'skinned mesh'} has incomplete skin attributes`);
+    }
+    if (!skinned.skeleton.bones.length || skinned.skeleton.boneInverses.length !== skinned.skeleton.bones.length) {
+      throw new Error(`Export failed: ${mesh.name || 'skinned mesh'} has an incomplete skeleton`);
+    }
+    for (let i = 0; i < skinIndex.count; i += 1) {
+      let weight = 0;
+      for (let component = 0; component < skinIndex.itemSize; component += 1) {
+        const joint = skinIndex.getComponent(i, component);
+        const influence = skinWeight.getComponent(i, component);
+        if (!Number.isFinite(joint) || joint < 0 || joint >= skinned.skeleton.bones.length) {
+          throw new Error(`Export failed: ${mesh.name || 'skinned mesh'} vertex ${i} targets an invalid joint`);
+        }
+        if (!Number.isFinite(influence) || influence < 0) {
+          throw new Error(`Export failed: ${mesh.name || 'skinned mesh'} vertex ${i} has an invalid skin weight`);
+        }
+        weight += influence;
+      }
+      if (weight < 1e-6) {
+        throw new Error(`Export failed: ${mesh.name || 'skinned mesh'} vertex ${i} has zero total skin weight`);
+      }
+    }
+  });
+  if (!visibleMeshes) throw new Error('Export failed: the authored model has no visible mesh');
+  const result = inventory(root);
+  if (!result.triangleCount) throw new Error('Export failed: the authored model contains zero triangles');
+  return result;
+}
+
+/**
+ * Clone without live mixers, closures or inspector overlays. UUIDs are intentionally retained on the
+ * isolated clone so clips authored against UUID track targets can still resolve during serialization.
+ */
+function cloneForExport(source: THREE.Group, selectedRoot?: THREE.Object3D): THREE.Group {
+  const saved = new Map<THREE.Object3D, Record<string, unknown>>();
+  const sourceNodes: THREE.Object3D[] = [];
+  source.traverse((node) => {
+    sourceNodes.push(node);
+    saved.set(node, node.userData);
+    node.userData = {};
+  });
+  const selectedIndex = selectedRoot ? sourceNodes.indexOf(selectedRoot) : -1;
+  if (selectedRoot && selectedIndex < 0) {
+    for (const [node, data] of saved) node.userData = data;
+    throw new Error('Export failed: the selected model is not part of this showcase assembly');
+  }
+  try {
+    const clean = cloneSkeleton(source) as THREE.Group;
+    const cleanNodes: THREE.Object3D[] = [];
+    clean.traverse((node) => {
+      cleanNodes.push(node);
+      node.userData = {};
+    });
+    const geometries = new Map<THREE.BufferGeometry, THREE.BufferGeometry>();
+    const materials = new Map<THREE.Material, THREE.Material>();
+    const convertedTextures = new Map<THREE.DataTexture, THREE.Texture>();
+    for (let i = 0; i < Math.min(sourceNodes.length, cleanNodes.length); i += 1) {
+      cleanNodes[i].uuid = sourceNodes[i].uuid;
+      const sourceMesh = sourceNodes[i] as THREE.Mesh;
+      const cleanMesh = cleanNodes[i] as THREE.Mesh;
+      if (!sourceMesh.isMesh || !cleanMesh.isMesh) continue;
+      let geometry = geometries.get(sourceMesh.geometry);
+      if (!geometry) {
+        geometry = sourceMesh.geometry.clone();
+        geometries.set(sourceMesh.geometry, geometry);
+      }
+      cleanMesh.geometry = geometry;
+      const cloneMaterial = (sourceMaterial: THREE.Material): THREE.Material => {
+        let material = materials.get(sourceMaterial);
+        if (!material) {
+          material = sourceMaterial.clone();
+          normalizeMaterialTextures(material, convertedTextures);
+          materials.set(sourceMaterial, material);
+        }
+        return material;
+      };
+      cleanMesh.material = Array.isArray(sourceMesh.material)
+        ? sourceMesh.material.map(cloneMaterial)
+        : cloneMaterial(sourceMesh.material);
+    }
+    if (selectedRoot && selectedRoot !== source) {
+      const cleanSelection = cleanNodes[selectedIndex];
+      if (!cleanSelection) throw new Error('Export failed: the selected model could not be cloned');
+      // Retain the complete selected subtree and its transform-bearing ancestor chain. Every sibling
+      // branch is removed, preserving the selected model's scale/pose relative to the showcase root.
+      let kept: THREE.Object3D = cleanSelection;
+      while (kept !== clean) {
+        const parent = kept.parent;
+        if (!parent) throw new Error('Export failed: the selected model clone lost its parent chain');
+        for (const sibling of [...parent.children]) {
+          if (sibling !== kept) parent.remove(sibling);
+        }
+        kept = parent;
+      }
+    }
+    // Viewer selection glows are removed synchronously by withAssetExportState() before cloning.
+    // Authored VFX also use isHighlight to stay out of picking/framing, so filtering that flag here
+    // incorrectly stripped real points, lines and effect meshes from exported GLB/glTF assets.
+    clean.name ||= 'img2threejs-asset';
+    clean.updateMatrixWorld(true);
+    return clean;
+  } finally {
+    for (const [node, data] of saved) node.userData = data;
+  }
+}
+
+function resolveTrackTarget(
+  root: THREE.Object3D,
+  binding: ReturnType<typeof THREE.PropertyBinding.parseTrackName>,
+): THREE.Object3D | undefined {
+  let target = THREE.PropertyBinding.findNode(root, binding.nodeName) as THREE.Object3D | undefined;
+  if (binding.objectName === 'bones') {
+    const skinned = target as THREE.SkinnedMesh | undefined;
+    target = skinned?.isSkinnedMesh
+      ? skinned.skeleton.getBoneByName(binding.objectIndex) ?? undefined
+      : undefined;
+  }
+  return target;
+}
+
+function sampledTimes(tracks: THREE.KeyframeTrack[], duration: number): number[] {
+  const values = new Set<number>([0, Math.max(0, duration)]);
+  for (const track of tracks) for (const time of track.times) values.add(time);
+  const frames = Math.ceil(Math.max(0, duration) * 60);
+  for (let frame = 1; frame < frames; frame += 1) values.add(frame / 60);
+  return [...values].filter(Number.isFinite).sort((a, b) => a - b);
+}
+
+function componentTrack(
+  target: THREE.Object3D,
+  property: 'position' | 'scale' | 'quaternion',
+  tracks: THREE.KeyframeTrack[],
+  duration: number,
+): THREE.KeyframeTrack {
+  const width = property === 'quaternion' ? 4 : 3;
+  const base = property === 'quaternion'
+    ? target.quaternion.toArray()
+    : target[property].toArray();
+  const times = sampledTimes(tracks, duration);
+  const interpolants = tracks.map((track) => ({
+    track,
+    binding: THREE.PropertyBinding.parseTrackName(track.name),
+    interpolant: track.createInterpolant(),
+  }));
+  const values: number[] = [];
+  for (const time of times) {
+    const current = [...base];
+    for (const entry of interpolants) {
+      const sampled = entry.interpolant.evaluate(time);
+      const component = COMPONENT_INDEX[entry.binding.propertyIndex];
+      if (component !== undefined) current[component] = sampled[0];
+      else for (let i = 0; i < Math.min(width, sampled.length); i += 1) current[i] = sampled[i];
+    }
+    values.push(...current);
+  }
+  const name = `${target.uuid}.${property}`;
+  return property === 'quaternion'
+    ? new THREE.QuaternionKeyframeTrack(name, times, values)
+    : new THREE.VectorKeyframeTrack(name, times, values);
+}
+
+/** Convert component/Euler tracks to glTF-native TRS tracks and remove non-portable runtime tracks. */
+function prepareAnimations(root: THREE.Object3D, source: THREE.AnimationClip[]): PreparedAnimations {
+  let droppedTracks = 0;
+  const clips: THREE.AnimationClip[] = [];
+  for (const sourceClip of source) {
+    const duration = sourceClip.duration >= 0
+      ? sourceClip.duration
+      : sourceClip.clone().resetDuration().duration;
+    const direct: THREE.KeyframeTrack[] = [];
+    const grouped = new Map<string, {
+      target: THREE.Object3D;
+      property: 'rotation' | 'position' | 'scale' | 'quaternion';
+      tracks: THREE.KeyframeTrack[];
+    }>();
+    for (const track of sourceClip.tracks) {
+      let binding: ReturnType<typeof THREE.PropertyBinding.parseTrackName>;
+      try {
+        binding = THREE.PropertyBinding.parseTrackName(track.name);
+      } catch {
+        droppedTracks += 1;
+        continue;
+      }
+      const target = resolveTrackTarget(root, binding);
+      if (!target) {
+        droppedTracks += 1;
+        continue;
+      }
+      const property = binding.propertyName;
+      if (property === 'rotation' || (
+        (property === 'position' || property === 'scale' || property === 'quaternion')
+        && binding.propertyIndex
+      )) {
+        const key = `${target.uuid}:${property}`;
+        const entry = grouped.get(key) ?? {
+          target,
+          property,
+          tracks: [],
+        };
+        entry.tracks.push(track);
+        grouped.set(key, entry);
+        continue;
+      }
+      if (property === 'position' || property === 'scale' || property === 'quaternion'
+        || property === 'morphTargetInfluences') {
+        direct.push(track.clone());
+      } else {
+        droppedTracks += 1;
+      }
+    }
+    for (const entry of grouped.values()) {
+      if (entry.property === 'rotation') {
+        const times = sampledTimes(entry.tracks, duration);
+        const interpolants = entry.tracks.map((track) => ({
+          binding: THREE.PropertyBinding.parseTrackName(track.name),
+          interpolant: track.createInterpolant(),
+        }));
+        const base = entry.target.rotation.clone();
+        const values: number[] = [];
+        const quaternion = new THREE.Quaternion();
+        for (const time of times) {
+          const euler = base.clone();
+          for (const item of interpolants) {
+            const sampled = item.interpolant.evaluate(time);
+            const component = COMPONENT_INDEX[item.binding.propertyIndex];
+            if (component === 0) euler.x = sampled[0];
+            else if (component === 1) euler.y = sampled[0];
+            else if (component === 2) euler.z = sampled[0];
+            else if (sampled.length >= 3) euler.set(sampled[0], sampled[1], sampled[2], base.order);
+          }
+          quaternion.setFromEuler(euler).toArray(values, values.length);
+        }
+        direct.push(new THREE.QuaternionKeyframeTrack(
+          `${entry.target.uuid}.quaternion`, times, values,
+        ));
+      } else {
+        direct.push(componentTrack(entry.target, entry.property, entry.tracks, duration));
+      }
+    }
+    if (direct.length) clips.push(new THREE.AnimationClip(sourceClip.name, duration, direct));
+  }
+  return { clips, sourceCount: source.length, droppedTracks };
+}
+
+function replaceChild(parent: THREE.Object3D, source: THREE.Object3D, replacement: THREE.Object3D): void {
+  const index = parent.children.indexOf(source);
+  parent.remove(source);
+  parent.add(replacement);
+  if (index >= 0) {
+    parent.children.splice(parent.children.indexOf(replacement), 1);
+    parent.children.splice(index, 0, replacement);
+  }
+}
+
+/** Bake morphs and skinning into ordinary mesh positions for formats without rig support. */
+function bakeDeformedMeshes(root: THREE.Group): THREE.Group {
+  root.updateMatrixWorld(true);
+  const replacements: Array<{ source: THREE.Mesh; mesh: THREE.Mesh; parent: THREE.Object3D }> = [];
+  const vertex = new THREE.Vector3();
+  root.traverse((node) => {
+    const mesh = node as THREE.Mesh;
+    const instanced = node as THREE.InstancedMesh;
+    if (!mesh.isMesh || !mesh.parent || instanced.isInstancedMesh) return;
+    const hasMorphs = !!mesh.morphTargetInfluences?.length;
+    const skinned = mesh as THREE.SkinnedMesh;
+    if (!skinned.isSkinnedMesh && !hasMorphs) return;
+    if (skinned.isSkinnedMesh) skinned.skeleton.update();
+    const geometry = mesh.geometry.clone();
+    const input = mesh.geometry.getAttribute('position');
+    const position = new Float32Array(input.count * 3);
+    for (let i = 0; i < input.count; i += 1) {
+      mesh.getVertexPosition(i, vertex);
+      position[i * 3] = vertex.x;
+      position[i * 3 + 1] = vertex.y;
+      position[i * 3 + 2] = vertex.z;
+    }
+    geometry.setAttribute('position', new THREE.BufferAttribute(position, 3));
+    geometry.deleteAttribute('skinIndex');
+    geometry.deleteAttribute('skinWeight');
+    geometry.morphAttributes = {};
+    geometry.computeVertexNormals();
+    const baked = new THREE.Mesh(geometry, mesh.material);
+    baked.name = mesh.name;
+    baked.position.copy(mesh.position);
+    baked.quaternion.copy(mesh.quaternion);
+    baked.scale.copy(mesh.scale);
+    baked.visible = mesh.visible;
+    baked.castShadow = mesh.castShadow;
+    baked.receiveShadow = mesh.receiveShadow;
+    for (const child of [...mesh.children]) baked.add(child);
+    replacements.push({ source: mesh, mesh: baked, parent: mesh.parent });
+  });
+  for (const item of replacements) replaceChild(item.parent, item.source, item.mesh);
+  root.updateMatrixWorld(true);
+  return root;
+}
+
+function tintedMaterial(material: THREE.Material, tint: THREE.Color | null): THREE.Material {
+  if (!tint) return material;
+  const clone = material.clone();
+  const coloured = clone as THREE.Material & { color?: THREE.Color };
+  if (coloured.color) coloured.color.multiply(tint);
+  return clone;
+}
+
+/** Expand GPU instances so OBJ/STL/PLY/USDZ receive every physical copy. */
+function expandInstances(root: THREE.Group): THREE.Group {
+  const replacements: Array<{
+    source: THREE.InstancedMesh;
+    group: THREE.Group;
+    parent: THREE.Object3D;
+  }> = [];
+  const matrix = new THREE.Matrix4();
+  const tint = new THREE.Color();
+  root.traverse((node) => {
+    const source = node as THREE.InstancedMesh;
+    if (!source.isInstancedMesh || !source.parent) return;
+    const group = new THREE.Group();
+    group.name = source.name || 'instances';
+    group.position.copy(source.position);
+    group.quaternion.copy(source.quaternion);
+    group.scale.copy(source.scale);
+    group.visible = source.visible;
+    for (let i = 0; i < source.count; i += 1) {
+      source.getMatrixAt(i, matrix);
+      const instanceTint = source.instanceColor ? (source.getColorAt(i, tint), tint.clone()) : null;
+      const materials = materialList(source).map((material) => tintedMaterial(material, instanceTint));
+      const mesh = new THREE.Mesh(source.geometry, Array.isArray(source.material) ? materials : materials[0]);
+      mesh.name = `${source.name || 'instance'}_${String(i + 1).padStart(3, '0')}`;
+      // Inactive particle/VFX slots legitimately use a singular zero-scale matrix. Decomposing a
+      // singular matrix divides by zero and produces a NaN quaternion, which then corrupts USDZ.
+      // Keeping the authored local matrix verbatim is both lossless and safe for every static writer.
+      mesh.matrixAutoUpdate = false;
+      mesh.matrix.copy(matrix);
+      mesh.castShadow = source.castShadow;
+      mesh.receiveShadow = source.receiveShadow;
+      group.add(mesh);
+    }
+    for (const child of [...source.children]) group.add(child);
+    replacements.push({ source, group, parent: source.parent });
+  });
+  for (const item of replacements) replaceChild(item.parent, item.source, item.group);
+  root.updateMatrixWorld(true);
+  return root;
+}
+
+function removeUnsupportedStaticRenderables(root: THREE.Group): THREE.Group {
+  const remove: THREE.Object3D[] = [];
+  root.traverse((node) => {
+    if ((node as THREE.Points).isPoints || (node as THREE.Line).isLine || (node as THREE.Sprite).isSprite) {
+      remove.push(node);
+    }
+  });
+  for (const node of remove.reverse()) node.removeFromParent();
+  root.updateMatrixWorld(true);
+  return root;
+}
+
+/**
+ * Three's OBJ/STL/PLY exporters traverse every mesh and do not honour Object3D.visible. Remove the
+ * top-most hidden subtrees after deformation has been baked so a static "from stage" file contains
+ * exactly the same renderable triangles as the inventory the visitor approved.
+ */
+function removeHiddenStaticSubtrees(root: THREE.Group): THREE.Group {
+  const hidden: THREE.Object3D[] = [];
+  root.traverse((node) => {
+    if (node === root || node.visible) return;
+    let ancestor = node.parent;
+    while (ancestor && ancestor !== root) {
+      if (!ancestor.visible) return;
+      ancestor = ancestor.parent;
+    }
+    hidden.push(node);
+  });
+  for (const node of hidden) node.removeFromParent();
+  root.updateMatrixWorld(true);
+  return root;
+}
+
+function ownedBuffer(view: ArrayBufferView): ArrayBuffer {
+  const bytes = new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function asBytes(value: ArrayBuffer | ArrayBufferView): Uint8Array {
+  return value instanceof ArrayBuffer
+    ? new Uint8Array(value)
+    : new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+}
+
+/**
+ * r169 writes two UV shader inputs with `token` types and omits the required scale/bias transform
+ * for 8-bit normal maps. Repair those declarations and rebuild the uncompressed archive with
+ * USDZ's required 64-byte file alignment.
+ */
+function repairUsdzShaderTypes(source: Uint8Array): Uint8Array {
+  const files = unzipSync(source);
+  const model = files['model.usda'];
+  if (!model) throw new Error('USDZ validation failed: model.usda is missing');
+  const original = strFromU8(model);
+  const repaired = original
+    .replace(/\btoken inputs:varname =/g, 'string inputs:varname =')
+    .replace(/\btoken inputs:in\.connect =/g, 'float2 inputs:in.connect =')
+    .replace(
+      /(def Shader "[^"]+_normal"\s*\{\s*uniform token info:id = "UsdUVTexture"\s*\n)/g,
+      '$1\t\t\tfloat4 inputs:scale = (2, 2, 2, 1)\n\t\t\tfloat4 inputs:bias = (-1, -1, -1, 0)\n',
+    );
+  if (repaired === original) return source;
+  files['model.usda'] = strToU8(repaired);
+
+  type AlignedFile = Uint8Array | [Uint8Array, { extra: Record<number, Uint8Array> }];
+  const aligned: Record<string, AlignedFile> = {};
+  let offset = 0;
+  for (const [filename, file] of Object.entries(files)) {
+    // Four bytes are reserved for the extra-field id/length header when padding is present.
+    const headerSize = 34 + filename.length;
+    offset += headerSize;
+    const offsetMod64 = offset & 63;
+    if (offsetMod64 !== 4) {
+      const padLength = 64 - offsetMod64;
+      aligned[filename] = [file, { extra: { 12345: new Uint8Array(padLength) } }];
+    } else {
+      aligned[filename] = file;
+    }
+    // Every payload starts at a 64-byte boundary, so only its length affects the next modulo.
+    offset = file.length;
+  }
+  return zipSync(aligned, { level: 0 });
+}
+
+function gltfJsonFromGlb(buffer: ArrayBuffer): Record<string, unknown> {
+  if (buffer.byteLength < 20) throw new Error('GLB validation failed: truncated header');
+  const view = new DataView(buffer);
+  if (view.getUint32(0, true) !== 0x46546c67) throw new Error('GLB validation failed: wrong magic');
+  if (view.getUint32(4, true) !== 2) throw new Error('GLB validation failed: unsupported version');
+  if (view.getUint32(8, true) !== buffer.byteLength) {
+    throw new Error('GLB validation failed: declared length differs from file size');
+  }
+  const jsonLength = view.getUint32(12, true);
+  if (view.getUint32(16, true) !== 0x4e4f534a || 20 + jsonLength > buffer.byteLength) {
+    throw new Error('GLB validation failed: invalid JSON chunk');
+  }
+  const json = new TextDecoder().decode(new Uint8Array(buffer, 20, jsonLength)).trimEnd();
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+function expectedAnimationChannels(clip: THREE.AnimationClip): number {
+  let channels = 0;
+  const morphTargets = new Set<string>();
+  for (const track of clip.tracks) {
+    const binding = THREE.PropertyBinding.parseTrackName(track.name);
+    if (binding.propertyName === 'morphTargetInfluences') {
+      morphTargets.add(`${binding.nodeName}:${binding.objectName}:${binding.objectIndex}`);
+    } else {
+      channels += 1;
+    }
+  }
+  return channels + morphTargets.size;
+}
+
+function gltfMaterialTextureIndices(materials: unknown[]): number[] {
+  const indices: number[] = [];
+  const visit = (value: unknown, key = ''): void => {
+    if (!value || typeof value !== 'object') return;
+    const record = value as Record<string, unknown>;
+    if (key.endsWith('Texture') && typeof record.index === 'number') {
+      indices.push(record.index);
+      return;
+    }
+    for (const [childKey, child] of Object.entries(record)) visit(child, childKey);
+  };
+  for (const material of materials) visit(material);
+  return indices;
+}
+
+function validateGltfDocument(
+  document: Record<string, unknown>,
+  expected: AssetInventory,
+  animations: THREE.AnimationClip[],
+): void {
+  const asset = document.asset as { version?: string } | undefined;
+  const scenes = document.scenes as unknown[] | undefined;
+  const meshes = document.meshes as Array<{ primitives?: Array<{
+    attributes?: Record<string, number>;
+    material?: number;
+    targets?: unknown[];
+  }> }> | undefined;
+  const nodes = document.nodes as Array<{ name?: string; mesh?: number; skin?: number }> | undefined;
+  const materials = document.materials as unknown[] | undefined;
+  const textures = document.textures as Array<{ source?: number }> | undefined;
+  const images = document.images as unknown[] | undefined;
+  const accessors = document.accessors as Array<{ min?: unknown[]; max?: unknown[] }> | undefined;
+  const skins = document.skins as Array<{ joints?: number[]; inverseBindMatrices?: number }> | undefined;
+  const encodedAnimations = document.animations as Array<{
+    name?: string;
+    channels?: unknown[];
+    samplers?: unknown[];
+  }> | undefined;
+  if (asset?.version !== '2.0' || !scenes?.length || !meshes?.length || !nodes?.length) {
+    throw new Error('glTF validation failed: asset, scene, mesh, or node table is missing');
+  }
+  const invalidAccessor = accessors?.findIndex((accessor) => (
+    [...(accessor.min ?? []), ...(accessor.max ?? [])]
+      .some((value) => typeof value !== 'number' || !Number.isFinite(value))
+  )) ?? -1;
+  if (invalidAccessor >= 0) {
+    throw new Error(`glTF validation failed: accessor ${invalidAccessor} has non-finite bounds`);
+  }
+  const primitives = meshes.flatMap((mesh) => mesh.primitives ?? []);
+  if (primitives.some((primitive) => primitive.attributes?.POSITION === undefined)) {
+    throw new Error('glTF validation failed: a mesh primitive has no POSITION accessor');
+  }
+  const meshNodeCount = nodes.filter((node) => node.mesh !== undefined).length;
+  if (meshNodeCount < expected.meshCount) {
+    throw new Error(
+      `glTF validation failed: expected at least ${expected.meshCount} mesh node(s), found ${meshNodeCount}`,
+    );
+  }
+  const primitivesForNode = (node: { mesh?: number }): Array<{
+    attributes?: Record<string, number>;
+    material?: number;
+    targets?: unknown[];
+  }> => node.mesh === undefined ? [] : meshes[node.mesh]?.primitives ?? [];
+  const colouredMeshNodes = nodes.filter((node) => primitivesForNode(node).some(
+    (primitive) => primitive.attributes?.COLOR_0 !== undefined,
+  )).length;
+  if (colouredMeshNodes < expected.vertexColourMeshCount) {
+    throw new Error(
+      `glTF validation failed: expected vertex colours on at least ${expected.vertexColourMeshCount} `
+      + `mesh node(s), found ${colouredMeshNodes}`,
+    );
+  }
+  const uvMeshNodes = nodes.filter((node) => primitivesForNode(node).some(
+    (primitive) => primitive.attributes?.TEXCOORD_0 !== undefined,
+  )).length;
+  if (uvMeshNodes < expected.uvMeshCount) {
+    throw new Error(
+      `glTF validation failed: expected UVs on at least ${expected.uvMeshCount} mesh node(s), `
+      + `found ${uvMeshNodes}`,
+    );
+  }
+  if ((materials?.length ?? 0) < expected.portableMaterialCount) {
+    throw new Error(
+      `glTF validation failed: expected at least ${expected.portableMaterialCount} portable material(s), `
+      + `found ${materials?.length ?? 0}`,
+    );
+  }
+  const textureIndices = gltfMaterialTextureIndices(materials ?? []);
+  if (textureIndices.length < expected.textureBindingCount) {
+    throw new Error(
+      `glTF validation failed: expected at least ${expected.textureBindingCount} texture binding(s), `
+      + `found ${textureIndices.length}`,
+    );
+  }
+  if (textureIndices.some((index) => !Number.isInteger(index) || index < 0 || index >= (textures?.length ?? 0))) {
+    throw new Error('glTF validation failed: a material references a missing texture');
+  }
+  if (expected.portableTextureCount > 0 && (!(textures?.length) || !(images?.length))) {
+    throw new Error('glTF validation failed: source texture images were lost');
+  }
+  if (textures?.some((texture) => (
+    texture.source === undefined || texture.source < 0 || texture.source >= (images?.length ?? 0)
+  ))) {
+    throw new Error('glTF validation failed: a texture references a missing image');
+  }
+  if (expected.morphTargetCount > 0
+    && !primitives.some((primitive) => (primitive.targets?.length ?? 0) > 0)) {
+    throw new Error('glTF validation failed: source morph targets were lost');
+  }
+  if (expected.skinnedMeshCount > 0) {
+    if (skins?.length !== expected.skinnedMeshCount
+      || skins.some((skin) => !skin.joints?.length || skin.inverseBindMatrices === undefined)) {
+      throw new Error('glTF validation failed: skin joints or inverse bind matrices are missing');
+    }
+    const weightedMeshNodes = nodes.filter((node) => node.skin !== undefined && primitivesForNode(node).some(
+      (primitive) => primitive.attributes?.JOINTS_0 !== undefined
+        && primitive.attributes?.WEIGHTS_0 !== undefined,
+    )).length;
+    if (weightedMeshNodes < expected.skinnedMeshCount) {
+      throw new Error(
+        `glTF validation failed: expected weights on at least ${expected.skinnedMeshCount} `
+        + `mesh node(s), found ${weightedMeshNodes}`,
+      );
+    }
+  }
+  if ((encodedAnimations?.length ?? 0) !== animations.length) {
+    throw new Error(
+      `glTF validation failed: expected ${animations.length} animation(s), found ${encodedAnimations?.length ?? 0}`,
+    );
+  }
+  for (const [index, animation] of (encodedAnimations ?? []).entries()) {
+    const wantedChannels = expectedAnimationChannels(animations[index]);
+    if (animation.channels?.length !== wantedChannels
+      || animation.channels.length !== animation.samplers?.length) {
+      throw new Error(`glTF validation failed: animation ${animation.name || 'unnamed'} has invalid channels`);
+    }
+  }
+  if (expected.instancedMeshCount > 0) {
+    const extensions = document.extensionsUsed as string[] | undefined;
+    if (!extensions?.includes('EXT_mesh_gpu_instancing')) {
+      throw new Error('glTF validation failed: GPU instances were not represented');
+    }
+  }
+  const exportedNames = new Set(nodes.map((node) => node.name).filter((name): name is string => !!name));
+  const missingNames = expected.namedParts.filter((name) => {
+    const safe = THREE.PropertyBinding.sanitizeNodeName(name);
+    return !exportedNames.has(name)
+      && !exportedNames.has(safe)
+      && ![...exportedNames].some((candidate) => candidate.startsWith(`${safe}_`));
+  });
+  if (missingNames.length) {
+    throw new Error(
+      `glTF validation failed: ${missingNames.length} named part(s) were lost (${missingNames.slice(0, 3).join(', ')})`,
+    );
+  }
+}
+
+async function validateGltfRoundTrip(
+  payload: ArrayBuffer | string,
+  expected: AssetInventory,
+  animations: THREE.AnimationClip[],
+): Promise<void> {
+  const loaded = await new GLTFLoader().parseAsync(payload, '');
+  const actual = inventory(loaded.scene);
+  if (!actual.meshCount || actual.triangleCount !== expected.triangleCount) {
+    throw new Error(
+      `glTF round-trip failed: expected ${expected.triangleCount} triangles, found ${actual.triangleCount}`,
+    );
+  }
+  if (actual.skinnedMeshCount < expected.skinnedMeshCount || actual.jointCount !== expected.jointCount) {
+    throw new Error(
+      `glTF round-trip failed: expected at least ${expected.skinnedMeshCount} skinned primitives/`
+      + `${expected.jointCount} joints, `
+      + `found ${actual.skinnedMeshCount}/${actual.jointCount}`,
+    );
+  }
+  if (actual.morphTargetCount < expected.morphTargetCount) {
+    throw new Error(
+      `glTF round-trip failed: expected at least ${expected.morphTargetCount} morph targets, `
+      + `found ${actual.morphTargetCount}`,
+    );
+  }
+  if (expected.vertexColourMeshCount > 0 && !actual.vertexColourMeshCount) {
+    throw new Error('glTF round-trip failed: vertex colours did not survive import');
+  }
+  if (actual.namedPartCount < expected.namedPartCount) {
+    throw new Error(
+      `glTF round-trip failed: expected at least ${expected.namedPartCount} named mesh part(s), `
+      + `found ${actual.namedPartCount}`,
+    );
+  }
+  if (actual.materialCount < expected.portableMaterialCount) {
+    throw new Error(
+      `glTF round-trip failed: expected at least ${expected.portableMaterialCount} portable material(s), `
+      + `found ${actual.materialCount}`,
+    );
+  }
+  if (actual.textureBindingCount < expected.textureBindingCount) {
+    throw new Error(
+      `glTF round-trip failed: expected at least ${expected.textureBindingCount} texture binding(s), `
+      + `found ${actual.textureBindingCount}`,
+    );
+  }
+  if (actual.uvMeshCount < expected.uvMeshCount) {
+    throw new Error(
+      `glTF round-trip failed: expected UVs on at least ${expected.uvMeshCount} mesh(es), `
+      + `found ${actual.uvMeshCount}`,
+    );
+  }
+  if (actual.instanceCount !== expected.instanceCount) {
+    throw new Error(
+      `glTF round-trip failed: expected ${expected.instanceCount} instances, found ${actual.instanceCount}`,
+    );
+  }
+  if (loaded.animations.length !== animations.length
+    || loaded.animations.some((clip, index) => clip.tracks.length !== expectedAnimationChannels(animations[index]))) {
+    throw new Error('glTF round-trip failed: animation clips or tracks did not survive import');
+  }
+}
+
+function validateStaticArtifact(
+  format: Exclude<ExportFormat, 'glb' | 'gltf'>,
+  bytes: Uint8Array,
+  expected: AssetInventory,
+  sourceText?: string,
+): void {
+  if (!bytes.byteLength) throw new Error(`${format.toUpperCase()} validation failed: empty file`);
+  if (format === 'obj') {
+    const vertices = sourceText?.match(/^v\s/gm)?.length ?? 0;
+    const faces = sourceText?.match(/^f\s/gm)?.length ?? 0;
+    const normals = sourceText?.match(/^vn\s/gm)?.length ?? 0;
+    const objects = sourceText?.match(/^o\s/gm)?.length ?? 0;
+    const uvs = sourceText?.match(/^vt\s/gm)?.length ?? 0;
+    if (!vertices || faces !== expected.triangleCount) {
+      throw new Error(`OBJ validation failed: expected ${expected.triangleCount} faces, found ${faces}`);
+    }
+    if (!normals) throw new Error('OBJ validation failed: normals were lost');
+    if (objects < expected.meshCount) {
+      throw new Error(
+        `OBJ validation failed: expected ${expected.meshCount} named mesh record(s), found ${objects}`,
+      );
+    }
+    if (expected.uvMeshCount > 0 && !uvs) {
+      throw new Error('OBJ validation failed: source UV coordinates were lost');
+    }
+    return;
+  }
+  if (format === 'stl') {
+    if (bytes.byteLength < 84) throw new Error('STL validation failed: truncated header');
+    const triangles = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(80, true);
+    if (triangles !== expected.triangleCount || bytes.byteLength !== 84 + triangles * 50) {
+      throw new Error(`STL validation failed: expected ${expected.triangleCount} triangles, found ${triangles}`);
+    }
+    return;
+  }
+  if (format === 'ply') {
+    const header = new TextDecoder().decode(bytes.subarray(0, Math.min(bytes.length, 8192)));
+    const end = header.indexOf('end_header\n');
+    const faces = Number(/element face (\d+)/.exec(header.slice(0, end))?.[1] ?? -1);
+    if (!header.startsWith('ply\n') || end < 0 || faces !== expected.triangleCount) {
+      throw new Error(`PLY validation failed: expected ${expected.triangleCount} faces, found ${faces}`);
+    }
+    if (expected.vertexColourMeshCount > 0 && !header.includes('property uchar red\n')) {
+      throw new Error('PLY validation failed: source vertex colours were lost');
+    }
+    if (expected.uvMeshCount > 0 && !header.includes('property float s\n')) {
+      throw new Error('PLY validation failed: source UV coordinates were lost');
+    }
+    return;
+  }
+  const signature = bytes[0] === 0x50 && bytes[1] === 0x4b && bytes[2] === 0x03 && bytes[3] === 0x04;
+  const files = signature ? unzipSync(bytes) : {};
+  const model = files['model.usda'];
+  const modelText = model ? strFromU8(model) : '';
+  const geometries = Object.keys(files).filter((name) => name.startsWith('geometries/Geometry_'));
+  const textureFiles = Object.keys(files).filter((name) => name.startsWith('textures/Texture_'));
+  const meshXforms = [...modelText.matchAll(/def Xform "Object_\d+"/g)].length;
+  if (!signature || !modelText.startsWith('#usda 1.0') || !geometries.length) {
+    throw new Error('USDZ validation failed: archive contains no renderable geometry');
+  }
+  if (meshXforms < expected.meshCount) {
+    throw new Error(
+      `USDZ validation failed: expected ${expected.meshCount} mesh transform(s), found ${meshXforms}`,
+    );
+  }
+  if (expected.textureCount > 0 && !textureFiles.length) {
+    throw new Error('USDZ validation failed: source material textures were lost');
+  }
+  if (/\btoken inputs:(?:varname|in\.connect) =/.test(modelText)) {
+    throw new Error('USDZ validation failed: material UV inputs have invalid USD types');
+  }
+  const normalShaders = [...modelText.matchAll(/def Shader "[^"]+_normal"\s*\{([\s\S]*?)\n\t\t\}/g)];
+  if (normalShaders.some(([, body]) => (
+    body.includes('uniform token info:id = "UsdUVTexture"')
+      && (!body.includes('float4 inputs:scale = (2, 2, 2, 1)')
+        || !body.includes('float4 inputs:bias = (-1, -1, -1, 0)'))
+  ))) {
+    throw new Error('USDZ validation failed: an 8-bit normal map has no USD scale/bias transform');
+  }
+}
+
+function toStandardMaterial(material: THREE.Material): THREE.MeshStandardMaterial {
+  const standard = material as THREE.MeshStandardMaterial;
+  if (standard.isMeshStandardMaterial) {
+    const compatible = standard.clone();
+    compatible.side = THREE.FrontSide;
+    return compatible;
+  }
+  const source = material as THREE.Material & {
+    color?: THREE.Color;
+    map?: THREE.Texture | null;
+    normalMap?: THREE.Texture | null;
+    emissive?: THREE.Color;
+    emissiveMap?: THREE.Texture | null;
+    alphaMap?: THREE.Texture | null;
+    aoMap?: THREE.Texture | null;
+    vertexColors?: boolean;
+    roughness?: number;
+    metalness?: number;
+  };
+  const converted = new THREE.MeshStandardMaterial({
+    color: source.color?.clone() ?? new THREE.Color(0xffffff),
+    map: source.map ?? null,
+    normalMap: source.normalMap ?? null,
+    emissive: source.emissive?.clone() ?? new THREE.Color(0x000000),
+    emissiveMap: source.emissiveMap ?? null,
+    alphaMap: source.alphaMap ?? null,
+    aoMap: source.aoMap ?? null,
+    roughness: source.roughness ?? 0.72,
+    metalness: source.metalness ?? 0,
+    opacity: material.opacity,
+    transparent: material.transparent,
+    alphaTest: material.alphaTest,
+    side: THREE.FrontSide,
+    vertexColors: source.vertexColors ?? false,
+  });
+  converted.name = material.name ? `${material.name}-usdz` : 'USDZ material';
+  return converted;
+}
+
+function sliceGeometry(source: THREE.BufferGeometry, start: number, count: number): THREE.BufferGeometry {
+  const flat = source.index ? source.toNonIndexed() : source;
+  const available = flat.getAttribute('position')?.count ?? 0;
+  const safeStart = Math.max(0, Math.min(start, available));
+  const safeCount = Math.max(0, Math.min(count, available - safeStart));
+  const result = new THREE.BufferGeometry();
+  for (const [name, attribute] of Object.entries(flat.attributes)) {
+    const values = new Float32Array(safeCount * attribute.itemSize);
+    for (let i = 0; i < safeCount; i += 1) {
+      for (let component = 0; component < attribute.itemSize; component += 1) {
+        values[i * attribute.itemSize + component] = attribute.getComponent(safeStart + i, component);
+      }
+    }
+    result.setAttribute(name, new THREE.BufferAttribute(values, attribute.itemSize));
+  }
+  result.computeBoundingBox();
+  result.computeBoundingSphere();
+  return result;
+}
+
+/** Normalize materials and split multi-material meshes for the stricter r169 USDZ exporter. */
+function prepareUsdz(root: THREE.Group): THREE.Group {
+  const multi: THREE.Mesh[] = [];
+  root.traverse((node) => {
+    const mesh = node as THREE.Mesh;
+    if (!mesh.isMesh) return;
+    if (Array.isArray(mesh.material)) multi.push(mesh);
+    else mesh.material = toStandardMaterial(mesh.material);
+  });
+  for (const mesh of multi.reverse()) {
+    const parent = mesh.parent;
+    if (!parent) continue;
+    const materials = mesh.material as THREE.Material[];
+    const positionCount = mesh.geometry.index?.count ?? mesh.geometry.getAttribute('position').count;
+    const groups = mesh.geometry.groups.length
+      ? mesh.geometry.groups
+      : [{ start: 0, count: positionCount, materialIndex: 0 }];
+    const container = new THREE.Group();
+    container.name = mesh.name;
+    container.position.copy(mesh.position);
+    container.quaternion.copy(mesh.quaternion);
+    container.scale.copy(mesh.scale);
+    container.visible = mesh.visible;
+    for (const [index, group] of groups.entries()) {
+      const geometry = sliceGeometry(mesh.geometry, group.start, group.count);
+      if ((geometry.getAttribute('position')?.count ?? 0) < 3) continue;
+      const material = materials[group.materialIndex ?? 0] ?? materials[0];
+      if (!material) continue;
+      const part = new THREE.Mesh(geometry, toStandardMaterial(material));
+      part.name = `${mesh.name || 'mesh'}-material-${index + 1}`;
+      part.castShadow = mesh.castShadow;
+      part.receiveShadow = mesh.receiveShadow;
+      container.add(part);
+    }
+    for (const child of [...mesh.children]) container.add(child);
+    replaceChild(parent, mesh, container);
+  }
+  root.updateMatrixWorld(true);
+  return root;
+}
+
+function reportFor(
+  format: ExportFormat,
+  bytes: number,
+  model: AssetInventory,
+  prepared: PreparedAnimations,
+  roundTripValidated: boolean,
+  warnings: string[],
+): ExportReport {
+  return {
+    format,
+    bytes,
+    meshCount: model.meshCount,
+    triangleCount: model.triangleCount,
+    namedPartCount: model.namedPartCount,
+    materialCount: model.materialCount,
+    portableMaterialCount: model.portableMaterialCount,
+    textureCount: model.textureCount,
+    portableTextureCount: model.portableTextureCount,
+    texturedMaterialCount: model.texturedMaterialCount,
+    textureBindingCount: model.textureBindingCount,
+    uvMeshCount: model.uvMeshCount,
+    vertexColourMeshCount: model.vertexColourMeshCount,
+    skinnedMeshCount: model.skinnedMeshCount,
+    jointCount: model.jointCount,
+    sourceAnimationCount: prepared.sourceCount,
+    animationCount: format === 'glb' || format === 'gltf' ? prepared.clips.length : 0,
+    animationTrackCount: format === 'glb' || format === 'gltf'
+      ? prepared.clips.reduce((sum, clip) => sum + clip.tracks.length, 0)
+      : 0,
+    morphTargetCount: model.morphTargetCount,
+    instanceCount: model.instanceCount,
+    roundTripValidated,
+    warnings,
+  };
+}
+
+/** Export a validated asset from the model currently mounted on stage. */
+export async function exportModel(
+  group: THREE.Group,
+  format: ExportFormat,
+  snapshot: ExportSnapshot = (work) => work(),
+  selectedRoot?: THREE.Object3D,
+): Promise<ExportArtifact> {
+  const clean = snapshot(() => cloneForExport(group, selectedRoot));
+  const stabilizedInstances = stabilizeInstanceMatrices(clean);
+  const sourceAnimations = animationsFor(group);
+  const capabilities = runtimeCapabilities(selectedRoot ?? group);
+  const model = validateGeometry(clean);
+  const prepared = prepareAnimations(clean, sourceAnimations);
+  const warnings: string[] = [];
+  if (stabilizedInstances) {
+    warnings.push(
+      `${stabilizedInstances} zero-scale instance transform(s) received neutral rotation and `
+      + `${INSTANCE_SCALE_EPSILON} scale epsilon for DCC compatibility`,
+    );
+  }
+  if (prepared.droppedTracks) {
+    warnings.push(`${prepared.droppedTracks} non-portable animation track(s) were omitted`);
+  }
+  if (prepared.clips.length !== prepared.sourceCount) {
+    warnings.push(`${prepared.sourceCount - prepared.clips.length} clip(s) had no portable TRS or morph tracks`);
+  }
+  if (model.unsupportedRenderableCount) {
+    warnings.push(`${model.unsupportedRenderableCount} runtime point/line/sprite effect(s) may not match in DCC tools`);
+  }
+  if (model.nonPbrMaterialCount) {
+    warnings.push(`${model.nonPbrMaterialCount} custom material(s) are approximated by destination formats`);
+  }
+  if ((format === 'glb' || format === 'gltf')
+    && model.textureCount === 0 && model.vertexColourMeshCount > 0) {
+    warnings.push(
+      `the source has no image textures; appearance is carried by ${model.vertexColourMeshCount} `
+      + 'vertex-colour mesh(es) and material values',
+    );
+  }
+  if ((format === 'glb' || format === 'gltf')
+    && model.textureCount > model.portableTextureCount) {
+    warnings.push(
+      `${model.textureCount - model.portableTextureCount} shader/runtime texture(s) have no portable glTF material slot`,
+    );
+  }
+  if (capabilities.hasAnimationController && !sourceAnimations.length) {
+    warnings.push('procedural runtime motion has no portable AnimationClip and is exported as the current pose');
+  }
+  if (capabilities.hasVfxRuntime) {
+    warnings.push('procedural runtime VFX logic is not representable in these interchange formats');
+  }
+
+  if (format === 'glb' || format === 'gltf') {
+    const binary = format === 'glb';
+    const output = await new GLTFExporter().parseAsync(clean, {
+      binary,
+      animations: prepared.clips,
+      trs: true,
+      onlyVisible: true,
+      truncateDrawRange: false,
+      includeCustomExtensions: false,
+    });
+    let payload: ArrayBuffer | string;
+    let blob: Blob;
+    let document: Record<string, unknown>;
+    if (binary) {
+      if (!(output instanceof ArrayBuffer)) {
+        throw new Error('GLB export failed: exporter returned non-binary data');
+      }
+      payload = output;
+      document = gltfJsonFromGlb(output);
+      blob = new Blob([output], { type: 'model/gltf-binary' });
+    } else {
+      const json = typeof output === 'string' ? output : JSON.stringify(output, null, 2);
+      payload = json;
+      document = JSON.parse(json) as Record<string, unknown>;
+      blob = new Blob([json], { type: 'model/gltf+json' });
+    }
+    validateGltfDocument(document, model, prepared.clips);
+    let roundTripValidated = false;
+    if (model.triangleCount <= ROUND_TRIP_TRIANGLE_LIMIT) {
+      await validateGltfRoundTrip(payload, model, prepared.clips);
+      roundTripValidated = true;
+    } else {
+      warnings.push(
+        `browser round-trip skipped above ${ROUND_TRIP_TRIANGLE_LIMIT.toLocaleString()} triangles to avoid exhausting memory`,
+      );
+    }
+    return {
+      blob,
+      filenameExtension: format,
+      report: reportFor(format, blob.size, model, prepared, roundTripValidated, warnings),
+    };
+  }
+
+  const posed = removeUnsupportedStaticRenderables(
+    expandInstances(removeHiddenStaticSubtrees(bakeDeformedMeshes(clean))),
+  );
+  const staticModel = validateGeometry(posed);
+  if (staticModel.triangleCount !== model.triangleCount) {
+    throw new Error(
+      `Static export validation failed: expected ${model.triangleCount} triangles after baking, found ${staticModel.triangleCount}`,
+    );
+  }
+  if (sourceAnimations.length || model.skinnedMeshCount) {
+    warnings.push('this static format contains the current posed geometry, not the rig or animation clips');
+  }
+  if (format === 'obj') {
+    warnings.push('OBJ keeps named mesh boundaries, UVs and normals, but this single-file export has no materials or textures');
+  } else if (format === 'stl') {
+    warnings.push('STL flattens the assembly to triangles; hierarchy, parts, materials, colours and UVs are not representable');
+  } else if (format === 'ply') {
+    warnings.push('PLY flattens the assembly; vertex colours survive, but hierarchy, named parts and materials do not');
+  } else if (format === 'usdz') {
+    warnings.push('USDZ contains a posed Quick Look asset; armatures and editable animation clips are not exported by Three.js r169');
+  }
+  if (format === 'obj') {
+    const text = new OBJExporter().parse(posed);
+    const bytes = new TextEncoder().encode(text);
+    validateStaticArtifact(format, bytes, staticModel, text);
+    const blob = new Blob([text], { type: 'text/plain' });
+    return {
+      blob,
+      filenameExtension: format,
+      report: reportFor(format, blob.size, staticModel, prepared, false, warnings),
+    };
+  }
+  if (format === 'stl') {
+    const data = new STLExporter().parse(posed, { binary: true });
+    const buffer = ownedBuffer(data);
+    validateStaticArtifact(format, new Uint8Array(buffer), staticModel);
+    const blob = new Blob([buffer], { type: 'model/stl' });
+    return {
+      blob,
+      filenameExtension: format,
+      report: reportFor(format, blob.size, staticModel, prepared, false, warnings),
+    };
+  }
+  if (format === 'ply') {
+    const exporter = new PLYExporter();
+    const result = exporter.parse(
+      posed,
+      () => undefined,
+      { binary: true, littleEndian: true },
+    );
+    if (!(result instanceof ArrayBuffer)) throw new Error('PLY export could not represent this geometry');
+    validateStaticArtifact(format, new Uint8Array(result), staticModel);
+    const blob = new Blob([result], { type: 'application/octet-stream' });
+    return {
+      blob,
+      filenameExtension: format,
+      report: reportFor(format, blob.size, staticModel, prepared, false, warnings),
+    };
+  }
+  const usdzRoot = prepareUsdz(posed);
+  const usdzModel = validateGeometry(usdzRoot);
+  const usdz = await new USDZExporter().parseAsync(usdzRoot, { quickLookCompatible: true });
+  const repairedUsdz = repairUsdzShaderTypes(asBytes(usdz));
+  const buffer = ownedBuffer(repairedUsdz);
+  validateStaticArtifact(format, new Uint8Array(buffer), usdzModel);
+  const blob = new Blob([buffer], { type: 'model/vnd.usdz+zip' });
+  return {
+    blob,
+    filenameExtension: format,
+    report: reportFor(format, blob.size, usdzModel, prepared, false, warnings),
+  };
+}
+
+function safeFilenamePart(value: string, fallback: string): string {
+  return value.trim().toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || fallback;
+}
+
+async function addBlobToZip(archive: Zip, filename: string, blob: Blob): Promise<void> {
+  const entry = new ZipPassThrough(filename);
+  archive.add(entry);
+  const reader = blob.stream().getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      entry.push(value);
+    }
+    entry.push(new Uint8Array(0), true);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/** Export every supported format into one streamed ZIP plus a machine-readable validation manifest. */
+export async function exportAllFormatsZip(
+  group: THREE.Group,
+  options: ExportBundleOptions,
+): Promise<ExportBundleArtifact> {
+  const assetId = safeFilenamePart(options.assetId, 'img2threejs-asset');
+  const scopeId = safeFilenamePart(options.scopeId, 'all');
+  const baseName = scopeId === 'all' ? assetId : `${assetId}--${scopeId}`;
+  const outputChunks: ArrayBuffer[] = [];
+  let archiveError: Error | undefined;
+  let resolveArchive!: (blob: Blob) => void;
+  let rejectArchive!: (error: Error) => void;
+  const completed = new Promise<Blob>((resolve, reject) => {
+    resolveArchive = resolve;
+    rejectArchive = reject;
+  });
+  const archive = new Zip((error, data, final) => {
+    if (error) {
+      archiveError = error;
+      rejectArchive(error);
+      return;
+    }
+    if (data.byteLength) outputChunks.push(ownedBuffer(data));
+    if (final) resolveArchive(new Blob(outputChunks, { type: 'application/zip' }));
+  });
+
+  const reports: ExportReport[] = [];
+  const files: string[] = [];
+  try {
+    for (const [index, definition] of EXPORT_FORMATS.entries()) {
+      options.onProgress?.({
+        format: definition.format,
+        label: definition.label,
+        index: index + 1,
+        total: EXPORT_FORMATS.length,
+      });
+      const artifact = await exportModel(
+        group,
+        definition.format,
+        options.snapshot,
+        options.selectedRoot,
+      );
+      if (archiveError) throw archiveError;
+      const filename = `${baseName}.${artifact.filenameExtension}`;
+      await addBlobToZip(archive, filename, artifact.blob);
+      if (archiveError) throw archiveError;
+      files.push(filename);
+      reports.push(artifact.report);
+    }
+
+    const manifest = {
+      schemaVersion: 1,
+      generator: 'img2threejs-showcase',
+      createdAt: new Date().toISOString(),
+      assetId: options.assetId,
+      scope: {
+        id: options.scopeId,
+        label: options.scopeLabel,
+        kind: options.selectedRoot ? 'declared-model' : 'full-assembly',
+      },
+      files: reports.map((report, index) => ({
+        filename: files[index],
+        format: report.format,
+        bytes: report.bytes,
+        report,
+      })),
+      portability: EXPORT_FORMATS.map(({ format, keeps, limits }) => ({ format, keeps, limits })),
+    };
+    await addBlobToZip(
+      archive,
+      'manifest.json',
+      new Blob([JSON.stringify(manifest, null, 2)], { type: 'application/json' }),
+    );
+    files.push('manifest.json');
+    if (archiveError) throw archiveError;
+    archive.end();
+    const blob = await completed;
+    return { blob, filename: `${baseName}-all-formats.zip`, files, reports };
+  } catch (error) {
+    archive.terminate();
+    throw error;
+  }
+}
+
+/** Hand an already validated blob to the browser as a named download. */
+export function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 5000);
+}

--- a/src/pages/demo.ts
+++ b/src/pages/demo.ts
@@ -148,6 +148,7 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
               <div class="parts-scroll"><ul class="parts-list" id="parts-list"></ul></div>
               <p class="parts-prov" id="parts-prov" hidden></p>
             </section>
+            <!-- Shared, unconditional export UI: every current and future DemoEntry inherits it. -->
             <section class="demo-export" id="demo-export" aria-labelledby="demo-export-title">
               <div class="demo-export-head">
                 <div>

--- a/src/pages/demo.ts
+++ b/src/pages/demo.ts
@@ -1,9 +1,20 @@
 import * as THREE from 'three';
+import '../export.css';
 import { getDemo } from '../demos/registry';
 import { Viewer, type PartInfo } from '../scene';
 import { navigate } from '../router';
 import { brand, extractVersion, escapeAttr, GITHUB_CORE as GITHUB_URL } from '../site-data';
 import { createLoader, whenViewerReady } from '../loader';
+import {
+  EXPORT_FORMATS,
+  exportAllFormatsZip,
+  exportModel,
+  exportModelsFor,
+  saveBlob,
+  type ExportFormat,
+  type ExportModelScope,
+  type ExportReport,
+} from '../exporters';
 import {
   resetExhibitOnceKeys,
   trackAnimationPlay,
@@ -136,6 +147,50 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
               <div class="part-card" id="part-card" hidden></div>
               <div class="parts-scroll"><ul class="parts-list" id="parts-list"></ul></div>
               <p class="parts-prov" id="parts-prov" hidden></p>
+            </section>
+            <section class="demo-export" id="demo-export" aria-labelledby="demo-export-title">
+              <div class="demo-export-head">
+                <div>
+                  <span class="parts-title" id="demo-export-title">Export a 3D Asset</span>
+                  <span class="demo-export-subtitle">From Stage</span>
+                </div>
+                <output class="demo-export-status" id="demo-export-status" data-state="ready">Ready</output>
+              </div>
+              <div class="demo-export-scope" id="demo-export-scope" hidden>
+                <label for="demo-export-scope-select">Export scope</label>
+                <select id="demo-export-scope-select" aria-describedby="demo-export-scope-note"></select>
+                <p id="demo-export-scope-note">Choose the complete assembly or one independently declared model.</p>
+              </div>
+              <div class="demo-export-formats" id="demo-export-formats">
+                ${EXPORT_FORMATS.map(({ format, label, note, keeps, limits }) => `
+                  <div class="demo-export-format-row" data-export-row="${format}">
+                    <button class="demo-export-format" type="button" data-export-format="${format}">
+                      <span class="demo-export-label">${label}</span>
+                      <span class="demo-export-note">${note}</span>
+                      <span class="demo-export-arrow" aria-hidden="true">&darr;</span>
+                    </button>
+                    <button class="demo-export-info" type="button" data-export-info="${format}"
+                            aria-label="What ${label} export includes"
+                            aria-describedby="demo-export-tooltip-${format}" aria-expanded="false">i</button>
+                    <div class="demo-export-tooltip" id="demo-export-tooltip-${format}" role="tooltip">
+                      <strong>${label} portability</strong>
+                      <p><span>Keeps</span>${keeps}</p>
+                      <p><span>Limits</span>${limits}</p>
+                    </div>
+                  </div>
+                `).join('')}
+              </div>
+              <button class="demo-export-all" id="demo-export-all" type="button">
+                <span>
+                  <strong>Export all formats</strong>
+                  <small>Current scope · 6 validated assets + manifest</small>
+                </span>
+                <span class="demo-export-zip" aria-hidden="true">.ZIP &darr;</span>
+              </button>
+              <div class="demo-export-report" id="demo-export-report" hidden>
+                <p id="demo-export-summary"></p>
+                <ul id="demo-export-warnings"></ul>
+              </div>
             </section>
             <div class="demo-links">
               <button class="btn btn-explode" id="demo-explode" type="button" aria-pressed="false" hidden>
@@ -391,6 +446,304 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
   }
 
   viewer.setExplodeRoot(model);
+  // --- validated asset export -----------------------------------------------------------
+  // Every format goes through one serializer and one validation path. The test hook returns only
+  // the JSON report (never the potentially huge Blob), so browser QA can exercise the exact same
+  // operation as a visitor without intercepting or retaining downloads.
+  const exportButtons = [...mount.querySelectorAll<HTMLButtonElement>('[data-export-format]')];
+  const exportStatus = mount.querySelector<HTMLOutputElement>('#demo-export-status');
+  const exportReport = mount.querySelector<HTMLElement>('#demo-export-report');
+  const exportSummary = mount.querySelector<HTMLElement>('#demo-export-summary');
+  const exportWarnings = mount.querySelector<HTMLUListElement>('#demo-export-warnings');
+  const exportScope = mount.querySelector<HTMLElement>('#demo-export-scope');
+  const exportScopeSelect = mount.querySelector<HTMLSelectElement>('#demo-export-scope-select');
+  const exportScopeNote = mount.querySelector<HTMLElement>('#demo-export-scope-note');
+  const exportAllButton = mount.querySelector<HTMLButtonElement>('#demo-export-all');
+  const exportAllNote = exportAllButton?.querySelector<HTMLElement>('small');
+  const exportInfoButtons = [...mount.querySelectorAll<HTMLButtonElement>('[data-export-info]')];
+  const exportButtonCleanups: Array<() => void> = [];
+  const exportReady: Promise<unknown> = demo.prewarm
+    ? demo.prewarm().catch(() => undefined)
+    : Promise.resolve();
+  let declaredExportModels: ExportModelScope[] = [];
+  let exportBusy = false;
+
+  const readableBytes = (bytes: number): string => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+  const showExportReport = (report: ExportReport): void => {
+    if (!exportReport || !exportSummary || !exportWarnings) return;
+    const materialFormat = report.format === 'glb' || report.format === 'gltf' || report.format === 'usdz';
+    const vertexColourFormat = report.format === 'glb' || report.format === 'gltf' || report.format === 'ply';
+    const facts = [
+      `${report.triangleCount.toLocaleString()} triangles`,
+      `${report.meshCount.toLocaleString()} mesh nodes`,
+      `${report.namedPartCount.toLocaleString()} named parts`,
+      materialFormat
+        ? report.portableMaterialCount === report.materialCount
+          ? `${report.materialCount.toLocaleString()} materials`
+          : `${report.portableMaterialCount.toLocaleString()}/${report.materialCount.toLocaleString()} portable materials`
+        : null,
+      materialFormat
+        ? report.portableTextureCount === report.textureCount
+          ? `${report.textureCount.toLocaleString()} image textures`
+          : `${report.portableTextureCount.toLocaleString()}/${report.textureCount.toLocaleString()} portable textures`
+        : null,
+      vertexColourFormat && report.vertexColourMeshCount
+        ? `${report.vertexColourMeshCount.toLocaleString()} vertex-colour meshes`
+        : null,
+      report.skinnedMeshCount ? `${report.jointCount.toLocaleString()} joints` : null,
+      report.sourceAnimationCount
+        ? `${report.animationCount}/${report.sourceAnimationCount} clips`
+        : null,
+      report.instanceCount ? `${report.instanceCount.toLocaleString()} instances` : null,
+      report.roundTripValidated ? 'round-trip passed' : null,
+      readableBytes(report.bytes),
+    ].filter((fact): fact is string => !!fact);
+    exportSummary.textContent = facts.join(' · ');
+    exportWarnings.replaceChildren();
+    for (const warning of report.warnings) {
+      const item = document.createElement('li');
+      item.textContent = warning;
+      exportWarnings.appendChild(item);
+    }
+    exportWarnings.hidden = report.warnings.length === 0;
+    exportReport.hidden = false;
+  };
+
+  const showExportError = (error: unknown, context: string): void => {
+    const message = error instanceof Error ? error.message : String(error);
+    if (exportSummary && exportReport && exportWarnings) {
+      exportSummary.textContent = message;
+      exportWarnings.replaceChildren();
+      exportWarnings.hidden = true;
+      exportReport.hidden = false;
+    }
+    if (exportStatus) {
+      exportStatus.value = 'Export blocked';
+      exportStatus.dataset.state = 'error';
+    }
+    console.error(`[export:${demo.id}:${context}]`, error);
+  };
+
+  const scopeForId = (scopeId = exportScopeSelect?.value ?? 'all'): ExportModelScope | undefined => (
+    scopeId === 'all' ? undefined : declaredExportModels.find((scope) => scope.id === scopeId)
+  );
+  const currentScope = (): { id: string; label: string; root?: THREE.Object3D } => {
+    const selected = scopeForId();
+    return selected ?? {
+      id: 'all',
+      label: declaredExportModels.length > 1
+        ? `All models (${declaredExportModels.length})`
+        : 'Complete showcase assembly',
+    };
+  };
+  const syncExportScopes = (): void => {
+    const previous = exportScopeSelect?.value ?? 'all';
+    declaredExportModels = exportModelsFor(model);
+    const multiple = declaredExportModels.length > 1;
+    if (!exportScope || !exportScopeSelect) return;
+    exportScope.hidden = !multiple;
+    exportScopeSelect.replaceChildren();
+    const all = document.createElement('option');
+    all.value = 'all';
+    all.textContent = `All models (${declaredExportModels.length})`;
+    exportScopeSelect.appendChild(all);
+    for (const scope of declaredExportModels) {
+      const option = document.createElement('option');
+      option.value = scope.id;
+      option.textContent = scope.label;
+      exportScopeSelect.appendChild(option);
+    }
+    exportScopeSelect.value = multiple && (previous === 'all' || scopeForId(previous)) ? previous : 'all';
+    if (exportScopeNote) {
+      exportScopeNote.textContent = multiple
+        ? `${declaredExportModels.length} independent models declared. Parts inside each model stay together.`
+        : 'The complete showcase assembly will be exported.';
+    }
+    if (exportAllNote) exportAllNote.textContent = 'Current scope · 6 validated assets + manifest';
+  };
+  syncExportScopes();
+  void exportReady.then(syncExportScopes);
+
+  const createExport = async (format: ExportFormat, scopeId?: string) => {
+    await exportReady;
+    syncExportScopes();
+    const selected = scopeForId(scopeId);
+    return exportModel(
+      model,
+      format,
+      (snapshot) => viewer.withAssetExportState(snapshot),
+      selected?.root,
+    );
+  };
+  const exportForQa = async (format: ExportFormat, scopeId = 'all'): Promise<ExportReport> => {
+    if (!EXPORT_FORMATS.some((entry) => entry.format === format)) {
+      throw new Error(`Unsupported export format: ${String(format)}`);
+    }
+    const report = (await createExport(format, scopeId)).report;
+    (window as unknown as Record<string, unknown>).__IMG2THREEJS_LAST_EXPORT_REPORT__ = report;
+    return report;
+  };
+  (window as unknown as Record<string, unknown>).__IMG2THREEJS_EXPORT__ = exportForQa;
+
+  const setExportBusy = (busy: boolean): void => {
+    exportBusy = busy;
+    for (const candidate of exportButtons) candidate.disabled = busy;
+    if (exportAllButton) exportAllButton.disabled = busy;
+    if (exportScopeSelect) exportScopeSelect.disabled = busy;
+  };
+  const showBundleReport = (
+    reports: ExportReport[],
+    bytes: number,
+    scopeLabel: string,
+  ): void => {
+    if (!exportReport || !exportSummary || !exportWarnings) return;
+    const warnings = [...new Set(reports.flatMap((report) => report.warnings))];
+    exportSummary.textContent = `${scopeLabel} · ${reports.length} formats · manifest.json · ${readableBytes(bytes)}`;
+    exportWarnings.replaceChildren();
+    for (const warning of warnings) {
+      const item = document.createElement('li');
+      item.textContent = warning;
+      exportWarnings.appendChild(item);
+    }
+    exportWarnings.hidden = warnings.length === 0;
+    exportReport.hidden = false;
+  };
+
+  const closeExportTooltips = (except?: HTMLElement): void => {
+    for (const row of mount.querySelectorAll<HTMLElement>('[data-export-row]')) {
+      if (row === except) continue;
+      row.classList.remove('is-info-open');
+      row.querySelector<HTMLButtonElement>('[data-export-info]')?.setAttribute('aria-expanded', 'false');
+    }
+  };
+  for (const button of exportInfoButtons) {
+    const onInfo = (event: MouseEvent): void => {
+      event.stopPropagation();
+      const row = button.closest<HTMLElement>('[data-export-row]');
+      if (!row) return;
+      const open = !row.classList.contains('is-info-open');
+      closeExportTooltips(row);
+      row.classList.toggle('is-info-open', open);
+      button.setAttribute('aria-expanded', String(open));
+    };
+    button.addEventListener('click', onInfo);
+    exportButtonCleanups.push(() => button.removeEventListener('click', onInfo));
+  }
+  const onExportOutsideClick = (event: MouseEvent): void => {
+    if (!(event.target as HTMLElement).closest('.demo-export-tooltip, [data-export-info]')) {
+      closeExportTooltips();
+    }
+  };
+  const onExportEscape = (event: KeyboardEvent): void => {
+    if (event.key !== 'Escape') return;
+    closeExportTooltips();
+    exportInfoButtons.find((button) => button.matches(':focus'))?.focus();
+  };
+  mount.addEventListener('click', onExportOutsideClick);
+  mount.addEventListener('keydown', onExportEscape);
+  exportButtonCleanups.push(() => mount.removeEventListener('click', onExportOutsideClick));
+  exportButtonCleanups.push(() => mount.removeEventListener('keydown', onExportEscape));
+
+  if (exportScopeSelect) {
+    const onScopeChange = (): void => {
+      const scope = currentScope();
+      if (exportStatus) {
+        exportStatus.value = scope.id === 'all' ? 'All models selected' : `${scope.label} selected`;
+        exportStatus.dataset.state = 'ready';
+      }
+      exportReport?.setAttribute('hidden', '');
+    };
+    exportScopeSelect.addEventListener('change', onScopeChange);
+    exportButtonCleanups.push(() => exportScopeSelect.removeEventListener('change', onScopeChange));
+  }
+
+  if (!capture) {
+    for (const button of exportButtons) {
+      const format = button.dataset.exportFormat as ExportFormat;
+      const onExport = async (): Promise<void> => {
+        if (exportBusy) return;
+        setExportBusy(true);
+        button.classList.add('is-exporting');
+        exportReport?.setAttribute('hidden', '');
+        const scope = currentScope();
+        if (exportStatus) {
+          exportStatus.value = `Validating ${format.toUpperCase()}`;
+          exportStatus.dataset.state = 'busy';
+        }
+        try {
+          const artifact = await createExport(format, scope.id);
+          (window as unknown as Record<string, unknown>).__IMG2THREEJS_LAST_EXPORT_REPORT__ = artifact.report;
+          showExportReport(artifact.report);
+          const filename = scope.id === 'all'
+            ? `${demo.id}.${artifact.filenameExtension}`
+            : `${demo.id}--${scope.id}.${artifact.filenameExtension}`;
+          saveBlob(artifact.blob, filename);
+          if (exportStatus) {
+            exportStatus.value = artifact.report.warnings.length ? 'Validated with limits' : 'Validated';
+            exportStatus.dataset.state = artifact.report.warnings.length ? 'warning' : 'success';
+          }
+        } catch (error) {
+          showExportError(error, format);
+        } finally {
+          setExportBusy(false);
+          button.classList.remove('is-exporting');
+        }
+      };
+      button.addEventListener('click', onExport);
+      exportButtonCleanups.push(() => button.removeEventListener('click', onExport));
+    }
+
+    if (exportAllButton) {
+      const onExportAll = async (): Promise<void> => {
+        if (exportBusy) return;
+        setExportBusy(true);
+        exportAllButton.classList.add('is-exporting');
+        exportReport?.setAttribute('hidden', '');
+        await exportReady;
+        syncExportScopes();
+        const scope = currentScope();
+        try {
+          const bundle = await exportAllFormatsZip(model, {
+            assetId: demo.id,
+            scopeId: scope.id,
+            scopeLabel: scope.label,
+            selectedRoot: scope.root,
+            snapshot: (snapshot) => viewer.withAssetExportState(snapshot),
+            onProgress: ({ label, index, total }) => {
+              if (exportStatus) {
+                exportStatus.value = `${label} ${index}/${total}`;
+                exportStatus.dataset.state = 'busy';
+              }
+            },
+          });
+          (window as unknown as Record<string, unknown>).__IMG2THREEJS_LAST_EXPORT_BUNDLE__ = {
+            bytes: bundle.blob.size,
+            filename: bundle.filename,
+            files: bundle.files,
+            reports: bundle.reports,
+          };
+          showBundleReport(bundle.reports, bundle.blob.size, scope.label);
+          saveBlob(bundle.blob, bundle.filename);
+          const hasWarnings = bundle.reports.some((report) => report.warnings.length > 0);
+          if (exportStatus) {
+            exportStatus.value = hasWarnings ? 'Bundle validated with limits' : 'Bundle validated';
+            exportStatus.dataset.state = hasWarnings ? 'warning' : 'success';
+          }
+        } catch (error) {
+          showExportError(error, 'zip');
+        } finally {
+          exportAllButton.classList.remove('is-exporting');
+          setExportBusy(false);
+        }
+      };
+      exportAllButton.addEventListener('click', onExportAll);
+      exportButtonCleanups.push(() => exportAllButton.removeEventListener('click', onExportAll));
+    }
+  }
   // QA capture scripts may place a diagnostic camera on a named socket. This
   // is not part of the demo UI or model geometry; it exposes only the existing
   // viewer instance to the local evidence harness.
@@ -819,6 +1172,12 @@ export function renderDemo(mount: HTMLElement, id: string): () => void {
     mount.removeEventListener('click', onPanelLinkClick);
     mountedAnimationController?.stop();
     unsubscribeAnimation?.();
+    if ((window as unknown as Record<string, unknown>).__IMG2THREEJS_EXPORT__ === exportForQa) {
+      delete (window as unknown as Record<string, unknown>).__IMG2THREEJS_EXPORT__;
+      delete (window as unknown as Record<string, unknown>).__IMG2THREEJS_LAST_EXPORT_REPORT__;
+      delete (window as unknown as Record<string, unknown>).__IMG2THREEJS_LAST_EXPORT_BUNDLE__;
+    }
+    for (const cleanup of exportButtonCleanups) cleanup();
     for (const cleanup of animationButtonCleanups) cleanup();
     viewer.dispose();
   };

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -398,6 +398,43 @@ export class Viewer {
     this.explodeParts = null; // recomputed lazily on first explode
   }
 
+  /**
+   * Run a synchronous asset snapshot against the authored assembly.
+   *
+   * Inspector highlights, isolation, explode offsets and the rig-debug material are viewer tools, not
+   * asset data. They are removed only for the duration of the clone and restored before the browser can
+   * render another frame. Bone transforms are deliberately left alone so static formats bake the pose
+   * the visitor is actually looking at.
+   */
+  withAssetExportState<T>(snapshot: () => T): T {
+    const rigWasOn = this.rigOn;
+    if (rigWasOn) this.setRigView(false);
+
+    const hidden = this.hiddenByIsolate.map((mesh) => ({ mesh, visible: mesh.visible }));
+    for (const item of hidden) item.mesh.visible = true;
+
+    const selected = this.selection;
+    this.clearHighlight();
+
+    const exploded = (this.explodeParts ?? []).map((part) => ({
+      object: part.object,
+      position: part.object.position.clone(),
+      rest: part.rest,
+    }));
+    for (const part of exploded) part.object.position.copy(part.rest);
+    this.explodeRoot?.updateMatrixWorld(true);
+
+    try {
+      return snapshot();
+    } finally {
+      for (const part of exploded) part.object.position.copy(part.position);
+      for (const item of hidden) item.mesh.visible = item.visible;
+      if (rigWasOn) this.setRigView(true);
+      if (selected) this.addHighlight(selected.object);
+      this.explodeRoot?.updateMatrixWorld(true);
+    }
+  }
+
   /** True once a root with more than one mesh is registered, i.e. worth offering the control. */
   get canExplode(): boolean {
     if (!this.explodeRoot) return false;


### PR DESCRIPTION
## Summary

- Adds validated in-browser export for GLB, glTF, OBJ, STL, PLY, and USDZ.
- Adds an info tooltip to every format describing exactly what is preserved and what the interchange format cannot carry.
- Preserves hierarchy, object names, portable PBR materials and embedded textures, UVs, normals, vertex colours, morph targets, skins, armatures, and authored AnimationClips in GLB/glTF when present in the source showcase.
- Adds explicit multi-model scope selection for Starship plus Super Heavy and the Sony charging case plus both earbuds.
- Adds Export all formats as one streamed ZIP with six assets and a machine-readable manifest.
- Exports from a clean authored-state snapshot so inspector highlight, isolate, explode, and rig-debug UI do not contaminate the asset.
- Adds browser, archive, format-parity, Blender import, and USD validation tools.

## Future showcase guarantee

- The export panel is part of the shared renderDemo path and is not gated by per-showcase metadata, so every new DemoEntry automatically inherits all six formats and ZIP export.
- The new-demo scaffold now targets the current authored registry, supplies updatedAt, names the generated roots, and explains the optional exportModels contract.
- A showcase containing multiple independent assets declares exportModels roots; a normal showcase exports its complete assembly without any extra setup.
- The export matrix parses the TypeScript registry instead of maintaining a hard-coded list, so new showcases are automatically included in subsequent QA.
- npm run qa:export:list provides a fast registry coverage check; npm run qa:export:matrix runs the full discovered matrix.

## Portability boundaries

- OBJ, STL, and PLY are baked static geometry formats and cannot carry an editable rig, animation clips, or the complete material graph.
- USDZ is a posed Quick Look preview with normalized materials.
- Procedural JavaScript VFX and motion, post-processing, and custom shader behavior are runtime code and cannot be reconstructed by general DCC interchange files. The new tooltips surface these limits before export.

## Validation

- npm run build: passed with TypeScript and Vite production build after both exporter and future-coverage changes.
- npm run qa:export:list: discovered all 24 registered upstream showcases.
- Isolated new-demo fixture: successfully generated future-export with updatedAt, named roots, inherited export guidance, and multi-model guidance.
- Starship branch QA: 6 tooltips, 3 scopes, desktop/mobile layout, selected-model GLBs, selected ZIP, full-assembly ZIP, seven expected archive entries, manifest byte parity, and hierarchy isolation all passed.
- Sony branch QA: 4 scopes and 3 independent selected-model GLBs passed; all six full-assembly formats passed.
- Blender 5.2.1 imports passed for Starship full assembly, both Starship scopes, Sony charging case, and both earbud scopes. Embedded image textures and textured materials were present.
- usdchecker returned Success for Starship and Sony USDZ files.
- The extended regression matrix reached 98 successful format exports: 16 complete showcases at 6/6 plus GLB and glTF for M9 Doppler. It was stopped on request after sufficient coverage. The four remaining M9 rows were recorded as page-closed cancellation artifacts, not exporter validation failures.

Large generated evidence files are intentionally not committed.