### PR TITLE
fix(scaffold): repair new-demo registry insertion (anchor drift, CRLF, missing updatedAt)

### DIFF
--- a/scripts/new-showcase.mjs
+++ b/scripts/new-showcase.mjs
@@ -82,12 +82,16 @@ export function ${factoryFnName}(): THREE.Group {
   // 2. Insert the import + registry entry.
   const importLine = `import { ${factoryFnName} } from './${id}/${factoryFnName}';\n`;
   const withImport = registrySource.replace(
-    /(^import \* as THREE from 'three';\n)/,
+    /(^import \* as THREE from 'three';\r?\n)/,
     `$1${importLine}`,
   );
+  if (withImport === registrySource) {
+    fail('could not find "import * as THREE from three" at the top of registry.ts.');
+  }
 
   const entryBlock = `  {
     id: '${id}',
+    updatedAt: '${new Date().toISOString().slice(0, 10)}',
     title: '${displayTitle.replace(/'/g, "\\'")}',
     subjectClass: '${subjectClass}',
     blurb:
@@ -110,13 +114,16 @@ export function ${factoryFnName}(): THREE.Group {
   },
 `;
 
+  // The demos array is `const authored: DemoEntry[] = [...spread]` in the current registry
+  // (the exported const is the spread result, which is not a valid insertion point). Accept
+  // either declaration so both old and new registries scaffold.
   const withEntry = withImport.replace(
-    /(export const demos: DemoEntry\[\] = \[\n)/,
+    /((?:const authored|export const demos): DemoEntry\[\] = \[\r?\n)/,
     `$1${entryBlock}`,
   );
 
   if (withEntry === withImport) {
-    fail('could not find "export const demos: DemoEntry[] = [" in registry.ts — insert the entry manually.');
+    fail('could not find "const authored: DemoEntry[] = [" in registry.ts — insert the entry manually.');
   }
 
   writeFileSync(registryFile, withEntry);


### PR DESCRIPTION
## Problem

`npm run new-demo` — step 1 of the documented "Add your own showcase" flow — fails on current `main` (verified at 0d75d2b):

1. The entry-insertion anchor looks for `export const demos: DemoEntry[] = [` + newline, but the registry now declares `const authored: DemoEntry[] = [` (the exported const is `[...authored]`, whose line never ends with an open bracket). The anchor can never match → "insert the entry manually".
2. Both insertion anchors are `\n`-exact, so on CRLF working trees (Windows default) even the import insertion silently fails — producing a registry that references an unimported factory and fails `tsc`.
3. A failed run leaves `src/demos/<id>/` behind, so the retry hits "already exists — pick a different id".
4. The scaffolded entry is missing the required `updatedAt` field, so `npm run build` fails even after the anchors are fixed.

## Fix

- Accept either `const authored` / `export const demos` as the entry anchor; tolerate `\r?\n` in both anchors.
- Fail loudly when the import anchor doesn't match instead of writing a broken registry.
- Stamp `updatedAt` on the scaffolded entry.

## Verification

- `npm run new-demo -- pr-scaffold-check "Scaffold Check" object` completes and inserts the entry into `const authored`; `npx tsc --noEmit` is clean; probe artifacts removed afterwards.
- Repeated with a CRLF-converted `registry.ts` to confirm the tolerance.